### PR TITLE
接入bbtools-pollevent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(bbt_coroutine SHARED ${SRCS})
 target_link_libraries(bbt_coroutine
     boost_context
     event_core
+    event_pthreads
+    bbt_pollevent
     ybbt
     # tcmalloc
 )

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -74,7 +74,7 @@ void CoPollEvent::_OnFinal()
     m_run_status = CoPollEventStatus::POLLEVENT_FINAL;
 }
 
-int CoPollEvent::RegistFdEvent(int fd, short events, int timeout)
+int CoPollEvent::InitFdEvent(int fd, short events, int timeout)
 {
     int ret = 0;
     if (m_run_status >= CoPollEventStatus::POLLEVENT_LISTEN || timeout < 0)
@@ -123,7 +123,7 @@ void CoPollEvent::_OnListen()
     m_run_status = CoPollEventStatus::POLLEVENT_LISTEN;
 }
 
-int CoPollEvent::UnRegistEvent()
+int CoPollEvent::UnRegist()
 {
     int ret = 0;
 

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -25,10 +25,9 @@ CoPollEvent::CoPollEvent(std::shared_ptr<Coroutine> coroutine, const CoPollEvent
 
 CoPollEvent::~CoPollEvent()
 {
-    if (m_timerfd >= 0) ::close(m_timerfd);
 }
 
-void CoPollEvent::Trigger(IPoller* poller, int trigger_events)
+void CoPollEvent::Trigger(short trigger_events)
 {
     /**
      * 触发事件实际操作由创建者定义，实现完全解耦。
@@ -57,45 +56,22 @@ void CoPollEvent::_OnFinal()
 }
 
 
-int CoPollEvent::GetEvent() const
-{
-    return m_type;
-}
+// int CoPollEvent::GetEvent() const
+// {
+//     return m_type;
+// }
 
-int CoPollEvent::InitFdReadableEvent(int fd)
-{
-    int ret = 0;
-    if (m_run_status >= CoPollEventStatus::POLLEVENT_LISTEN || fd < 0)
-        return -1;
-
-    m_ref_fd = fd;
-    m_type |= PollEventType::POLL_EVENT_READABLE;
-    return ret;
-}
-
-int CoPollEvent::InitFdWriteableEvent(int fd)
+int CoPollEvent::RegistFdEvent(int fd, short events, int timeout)
 {
     int ret = 0;
-    if (m_run_status >= CoPollEventStatus::POLLEVENT_LISTEN || fd < 0)
+    if (m_run_status >= CoPollEventStatus::POLLEVENT_LISTEN || timeout < 0)
         return -1;
     
-    m_ref_fd = fd;
-    m_type |= PollEventType::POLL_EVENT_WRITEABLE;
-    return ret;
-}
-
-int CoPollEvent::InitTimeoutEvent(int timeout)
-{
-    int ret = 0;
-    if (m_run_status >= CoPollEventStatus::POLLEVENT_LISTEN || timeout <= 0)
-        return -1;
-
     m_timeout = timeout;
-    m_timerfd = ::timerfd_create(CLOCK_REALTIME, 0);
-    if (m_timerfd < 0)
-        return -1;
+    m_event = g_bbt_poller->CreateEvent(fd, events, [this](std::shared_ptr<bbt::pollevent::Event>, short events){
+        Trigger(events);
+    });
 
-    m_type |= PollEventType::POLL_EVENT_TIMEOUT;
     return ret;
 }
 
@@ -106,7 +82,7 @@ int CoPollEvent::InitCustomEvent(int key, void* args)
 
     m_has_custom_event = true;
     m_custom_key = key;
-    m_type |= PollEventType::POLL_EVENT_CUSTOM;
+    // m_type |= PollEventType::POLL_EVENT_CUSTOM;
     return 0;
 }
 
@@ -115,57 +91,33 @@ int CoPollEvent::Regist()
     /**
      * 目前不支持同时注册可读、可写事件
      */
-    Assert( ! (m_type & PollEventType::POLL_EVENT_READABLE && m_type & PollEventType::POLL_EVENT_WRITEABLE) );
+    // Assert( ! (m_type & PollEventType::POLL_EVENT_READABLE && m_type & PollEventType::POLL_EVENT_WRITEABLE) );
 
-    /* fd 可读事件 */
-    if (m_ref_fd >= 0 && (m_type & PollEventType::POLL_EVENT_READABLE) && (_RegistFdReadableEvent() != 0))
-        return -1;
-
-    /* fd 可写事件 */
-    if (m_ref_fd >= 0 && (m_type & PollEventType::POLL_EVENT_WRITEABLE) && (_RegistFdWriteableEvent() != 0))
-        return -1;
-
-    /* 超时事件 */
-    if (m_timerfd >= 0 && (m_type & PollEventType::POLL_EVENT_TIMEOUT) && (_RegistTimeoutEvent() != 0))
+    if (m_event != nullptr && (_RegistFdEvent() != 0))
         return -1;
 
     /* 自定义事件 */
-    if (m_has_custom_event && (m_type & PollEventType::POLL_EVENT_CUSTOM) && (_RegistCustomEvent() != 0))
+    if (m_has_custom_event && (_RegistCustomEvent() != 0))
         return -1;
 
     _OnListen();
     return 0;
 }
 
-int CoPollEvent::_CreateEpollEvent(int fd, int events)
-{
-    epoll_event event;
-    event.events = events;
-    event.data.ptr = new PrivData{shared_from_this()};
+// void CoPollEvent::_DestoryEpollEvent(int fd)
+// {
+//     // std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
+//     auto it = m_epoll_event_map.find(fd);
+//     if (it == m_epoll_event_map.end())
+//         return;
+//     auto event = it->second;
 
-    std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-    auto it = m_epoll_event_map.find(fd);
-    if (it != m_epoll_event_map.end())
-        return -1;
-    
-    m_epoll_event_map[fd] = event;
-    return 0;
-}
+//     if (event.data.ptr == nullptr)
+//         return;
 
-void CoPollEvent::_DestoryEpollEvent(int fd)
-{
-    // std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-    auto it = m_epoll_event_map.find(fd);
-    if (it == m_epoll_event_map.end())
-        return;
-    auto event = it->second;
-
-    if (event.data.ptr == nullptr)
-        return;
-
-    ((PrivData*)event.data.ptr)->event_sptr = nullptr;
-    delete (PrivData*)event.data.ptr;
-}
+//     ((PrivData*)event.data.ptr)->event_sptr = nullptr;
+//     delete (PrivData*)event.data.ptr;
+// }
 
 void CoPollEvent::_OnListen()
 {
@@ -183,7 +135,7 @@ int CoPollEvent::UnRegistEvent()
 
     if (ret == 0)
     {
-        _CannelAllFdEvent();
+        m_event->CancelListen();
         m_run_status = CoPollEventStatus::POLLEVENT_CANNEL;
     }
 
@@ -195,70 +147,11 @@ int CoPollEvent::_RegistCustomEvent()
     return 0;
 }
 
-int CoPollEvent::_RegistTimeoutEvent()
+int CoPollEvent::_RegistFdEvent()
 {
-    int ret = 0;
-    itimerspec new_value;
-    timespec   now;
-
-    if (m_timerfd < 0)
-        return -1;
-    
-    if (clock_gettime(CLOCK_REALTIME, &now) != 0)
-        return -1;
-    
-    int64_t nsec = now.tv_nsec + (m_timeout % 1000) * 1000000;
-
-    new_value.it_value.tv_sec = now.tv_sec + (m_timeout / 1000) + (nsec >= 1000000000 ? 1 : 0);
-    new_value.it_value.tv_nsec = (nsec >= 1000000000 ? nsec - 1000000000 : nsec);
-    new_value.it_interval.tv_nsec = 0;
-    new_value.it_interval.tv_sec = 0;
-
-    if (timerfd_settime(m_timerfd, TFD_TIMER_ABSTIME, &new_value, NULL) != 0)
-        return -1;
-    
-    _CreateEpollEvent(m_timerfd, EPOLLIN | EPOLLONESHOT);
-
-    ret = g_bbt_poller->AddFdEvent(shared_from_this(), m_timerfd);
-    if (ret != 0) {
-        std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-        _DestoryEpollEvent(m_timerfd);
-        g_bbt_warn_print;
-    }
-
-    return ret;
+    return m_event->StartListen(m_timeout);
 }
 
-int CoPollEvent::_RegistFdEvent(int io_event)
-{
-    int ret = 0;
-    if (m_ref_fd < 0)
-        return -1;
-
-    ret = _CreateEpollEvent(m_ref_fd, io_event | EPOLLONESHOT | EPOLLET);
-    if (ret != 0)
-        return ret;
-
-    ret = g_bbt_poller->AddFdEvent(shared_from_this(), m_ref_fd);
-
-    if (ret != 0) {
-        std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-        _DestoryEpollEvent(m_ref_fd);
-        g_bbt_warn_print;
-    }
-
-    return ret;
-}
-
-int CoPollEvent::_RegistFdWriteableEvent()
-{
-    return _RegistFdEvent(EPOLLOUT);
-}
-
-int CoPollEvent::_RegistFdReadableEvent()
-{
-    return _RegistFdEvent(EPOLLIN);
-}
 
 int CoPollEvent::_CannelAllFdEvent()
 {
@@ -266,25 +159,23 @@ int CoPollEvent::_CannelAllFdEvent()
     if (m_run_status != CoPollEventStatus::POLLEVENT_LISTEN)
         return -1;
     
-    std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-
-    for (auto&& it : m_epoll_event_map) {
-        Assert(g_bbt_poller->DelFdEvent(it.first) == 0);
-        _DestoryEpollEvent(it.first);
+    if (m_event != nullptr) {
+        ret = m_event->CancelListen();
+        m_event = nullptr;
     }
 
     return ret;
 }
 
-epoll_event* CoPollEvent::GetEpollEvent(int fd)
-{
-    std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
-    auto it = m_epoll_event_map.find(fd);
-    if (it == m_epoll_event_map.end())
-        return nullptr;
+// epoll_event* CoPollEvent::GetEpollEvent(int fd)
+// {
+//     std::unique_lock<std::mutex> _(m_epoll_event_map_mutex);
+//     auto it = m_epoll_event_map.find(fd);
+//     if (it == m_epoll_event_map.end())
+//         return nullptr;
 
-    return &(it->second);
-}
+//     return &(it->second);
+// }
 
 bool CoPollEvent::IsListening() const
 {

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -33,13 +33,11 @@ public:
     CoPollEventStatus               GetStatus() const;
 
     void                            Trigger(short trigger_events);
-    /* 下面3个函数注册不同的事件，但是事件在第一次触发后失效 */
-
-    int                             RegistFdEvent(int fd, short events, int timeout);
+    /* 初始化后调用Regist注册事件 */
+    int                             InitFdEvent(int fd, short events, int timeout);
     int                             InitCustomEvent(int key, void* args);
     int                             Regist();
-
-    int                             UnRegistEvent();
+    int                             UnRegist();
 
 protected:
     int                             _RegistCustomEvent();

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <bbt/base/Attribute.hpp>
+#include <bbt/pollevent/Event.hpp>
 #include <bbt/coroutine/detail/Define.hpp>
 #include <bbt/coroutine/detail/interface/IPollEvent.hpp>
 
@@ -14,7 +15,7 @@ namespace bbt::coroutine::detail
  * 辅助协程实现挂起和唤醒
  */
 class CoPollEvent:
-    public IPollEvent,
+    // public IPollEvent,
     public std::enable_shared_from_this<CoPollEvent>
 {
 public:
@@ -26,17 +27,16 @@ public:
     BBTATTR_FUNC_Ctor_Hidden        CoPollEvent(std::shared_ptr<Coroutine> coroutine, const CoPollEventCallback& cb);
                                     ~CoPollEvent();
 
-    virtual int                     GetEvent() const override;
-    epoll_event*                    GetEpollEvent(int fd);
+    // int                             GetEvent() const;
+    // epoll_event*                    GetEpollEvent(int fd);
     bool                            IsListening() const;
     bool                            IsFinal() const;
     CoPollEventStatus               GetStatus() const;
 
-    virtual void                    Trigger(IPoller* poller, int trigger_events) override;
+    void                            Trigger(short trigger_events);
     /* 下面3个函数注册不同的事件，但是事件在第一次触发后失效 */
-    int                             InitFdReadableEvent(int fd);
-    int                             InitFdWriteableEvent(int fd);
-    int                             InitTimeoutEvent(int timeout);
+
+    int                             RegistFdEvent(int fd, short events, int timeout);
     int                             InitCustomEvent(int key, void* args);
     int                             Regist();
 
@@ -46,29 +46,19 @@ public:
     struct PrivData {std::shared_ptr<IPollEvent> event_sptr{nullptr};};
 protected:
     int                             _RegistCustomEvent();
-    int                             _RegistTimeoutEvent();
-    int                             _RegistFdEvent(int io_event);
-    int                             _RegistFdWriteableEvent();
-    int                             _RegistFdReadableEvent();
+    int                             _RegistFdEvent();
     int                             _CannelAllFdEvent();
-
-    int                             _CreateEpollEvent(int fd, int epoll_events);
-    void                            _DestoryEpollEvent(int fd);
 
     void                            _OnListen();
     void                            _OnFinal();
 private:
     std::shared_ptr<Coroutine>      m_coroutine{nullptr};
-    int                             m_ref_fd{-1};
-    int                             m_type{PollEventType::POLL_EVENT_DEFAULT};
-    int                             m_timerfd{-1};
+    std::shared_ptr<bbt::pollevent::Event>
+                                    m_event{nullptr};
+    // int                             m_type{PollEventType::POLL_EVENT_DEFAULT};
     int                             m_timeout{-1};
     bool                            m_has_custom_event{false};
     int                             m_custom_key{-1};
-    /* 事件对象内部保存注册到epoll时的结构体，自己管理生命期更安全 */
-    std::unordered_map<int, epoll_event>
-                                    m_epoll_event_map;
-    std::mutex                      m_epoll_event_map_mutex;
 
     CoPollEventCallback             m_onevent_callback{nullptr};
     volatile CoPollEventStatus      m_run_status{CoPollEventStatus::POLLEVENT_DEFAULT};

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -27,8 +27,7 @@ public:
     BBTATTR_FUNC_Ctor_Hidden        CoPollEvent(std::shared_ptr<Coroutine> coroutine, const CoPollEventCallback& cb);
                                     ~CoPollEvent();
 
-    // int                             GetEvent() const;
-    // epoll_event*                    GetEpollEvent(int fd);
+    int                             GetEvent() const;
     bool                            IsListening() const;
     bool                            IsFinal() const;
     CoPollEventStatus               GetStatus() const;
@@ -42,8 +41,6 @@ public:
 
     int                             UnRegistEvent();
 
-    /* 这个类用来包裹对象的智能指针，防止事件被意外被释放 */
-    struct PrivData {std::shared_ptr<IPollEvent> event_sptr{nullptr};};
 protected:
     int                             _RegistCustomEvent();
     int                             _RegistFdEvent();
@@ -55,7 +52,6 @@ private:
     std::shared_ptr<Coroutine>      m_coroutine{nullptr};
     std::shared_ptr<bbt::pollevent::Event>
                                     m_event{nullptr};
-    // int                             m_type{PollEventType::POLL_EVENT_DEFAULT};
     int                             m_timeout{-1};
     bool                            m_has_custom_event{false};
     int                             m_custom_key{-1};

--- a/bbt/coroutine/detail/CoPoller.cc
+++ b/bbt/coroutine/detail/CoPoller.cc
@@ -16,86 +16,47 @@ CoPoller::UPtr& CoPoller::GetInstance()
 
 
 CoPoller::CoPoller():
-    m_epoll_fd(::epoll_create(65535))
+    m_event_loop(std::make_shared<bbt::pollevent::EventLoop>())
 {
-    AssertWithInfo(m_epoll_fd >= 0, "epoll_create() failed!");
 }
 
 CoPoller::~CoPoller()
 {
-    
 }
 
-int CoPoller::AddFdEvent(std::shared_ptr<IPollEvent> ievent, int fd)
+
+std::shared_ptr<bbt::pollevent::Event> CoPoller::CreateEvent(int fd, short events, const bbt::pollevent::OnEventCallback& onevent_cb)
 {
-    auto co_event = std::dynamic_pointer_cast<CoPollEvent>(ievent);
-
-    /* 防止重复注册 */
-    if (co_event->GetStatus() != CoPollEventStatus::POLLEVENT_INITED)
-        return -1;
-
-    auto ev = co_event->GetEpollEvent(fd);
-
-    return epoll_ctl(m_epoll_fd, EPOLL_CTL_ADD, fd, ev);
+    return m_event_loop->CreateEvent(fd, events, onevent_cb);
 }
 
-int CoPoller::DelFdEvent(int fd)
+bool CoPoller::PollOnce()
 {
-    int ret = 0;
-    return ::epoll_ctl(m_epoll_fd, EPOLL_CTL_DEL, fd, NULL);
-}
+    bool ret = (m_event_loop->StartLoop(bbt::pollevent::EventLoopOpt::LOOP_NONBLOCK) == 0);
 
-int CoPoller::ModifyFdEvent(std::shared_ptr<IPollEvent> event, int fd, int event_opt)
-{
-    // int ret = 0;
-    // epoll_event ev;
-
-    // ev.events = modify_event;
-    // ret = ::epoll_ctl(m_epoll_fd, EPOLL_CTL_MOD, event->GetFd(), &ev);
-
-    return -1;
-}
-
-int CoPoller::PollOnce()
-{
-    const int max_event_num = 1024;
-    epoll_event events[max_event_num];
-    int active_event_num = ::epoll_wait(m_epoll_fd, events, max_event_num, 0);
-
-    /* 通知触发的内核fd事件 */
-    for (int i = 0; i < active_event_num; ++i)
-    {
-        auto& event = events[i];
-        auto privdata = reinterpret_cast<CoPollEvent::PrivData*>(event.data.ptr);
-        auto event_sptr = std::dynamic_pointer_cast<CoPollEvent>(privdata->event_sptr);
-
-        /* 注销事件，并触发事件通知监听者 */
-        // event_sptr->_CannelAllFdEvent();
-        event_sptr->Trigger(this, event.events);
-    }
-
-    std::queue<std::shared_ptr<IPollEvent>> m_swap_queue;
+    std::queue<std::shared_ptr<CoPollEvent>> m_swap_queue;
     {
         std::unique_lock<std::mutex> _(m_custom_event_active_queue_mutex);
         m_swap_queue.swap(m_custom_event_active_queue);
     }
 
-    active_event_num += m_swap_queue.size();
+    if (!m_swap_queue.empty())
+        ret = true;
 
     /* 通知触发的自定义事件 */
     while (!m_swap_queue.empty())
     {
         auto item = m_swap_queue.front();
-        item->Trigger(this, POLL_EVENT_CUSTOM);
+        item->Trigger(POLL_EVENT_CUSTOM);
         m_swap_queue.pop();
         std::unique_lock<std::mutex> _(m_custom_event_active_queue_mutex);
         Assert(m_safe_active_set.erase(item) > 0);
     }
 
-    return active_event_num;
+    return ret;
 }
 
-int CoPoller::NotifyCustomEvent(std::shared_ptr<IPollEvent> event)
+int CoPoller::NotifyCustomEvent(std::shared_ptr<CoPollEvent> event)
 {
     std::unique_lock<std::mutex> _(m_custom_event_active_queue_mutex);
     // AssertWithInfo(m_safe_active_set.find(event) != m_safe_active_set.end(), "有bug，这里不应该有重复的事件");

--- a/bbt/coroutine/detail/Coroutine.cc
+++ b/bbt/coroutine/detail/Coroutine.cc
@@ -96,7 +96,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistTimeout(int ms)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->RegistFdEvent(-1, EventOpt::TIMEOUT, ms) != 0)
+    if (m_await_event->InitFdEvent(-1, EventOpt::TIMEOUT, ms) != 0)
         return nullptr;
 
     if (m_await_event->Regist() != 0)
@@ -137,7 +137,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistCustom(int key, int timeout_ms)
     if (m_await_event->InitCustomEvent(key, NULL) != 0)
         return nullptr;
     
-    if (m_await_event->RegistFdEvent(-1, EventOpt::TIMEOUT, timeout_ms) != 0)
+    if (m_await_event->InitFdEvent(-1, EventOpt::TIMEOUT, timeout_ms) != 0)
         return nullptr;
     
     if (m_await_event->Regist() != 0)
@@ -156,7 +156,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdReadable(int fd)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->RegistFdEvent(fd, EventOpt::READABLE, 0) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE, 0) != 0)
         return nullptr;
     
     if (m_await_event->Regist() != 0)
@@ -175,7 +175,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdReadable(int fd, int timeout_ms)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->RegistFdEvent(fd, EventOpt::READABLE | EventOpt::TIMEOUT, timeout_ms))
+    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE | EventOpt::TIMEOUT, timeout_ms))
         return nullptr;
 
     if (m_await_event->Regist() != 0)
@@ -194,7 +194,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdWriteable(int fd)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->RegistFdEvent(fd, EventOpt::WRITEABLE, 0) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE, 0) != 0)
         return nullptr;
     
     if (m_await_event->Regist() != 0)
@@ -213,7 +213,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdWriteable(int fd, int timeout_ms
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->RegistFdEvent(fd, EventOpt::WRITEABLE | EventOpt::TIMEOUT, timeout_ms) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE | EventOpt::TIMEOUT, timeout_ms) != 0)
         return nullptr;
 
     if (m_await_event->Regist() != 0)

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -23,9 +23,6 @@ class Coroutine:
     public std::enable_shared_from_this<Coroutine>
 {
 public:
-    friend class Processer;
-    friend class sync::CoCond;
-    friend int Hook_Sleep(int);
     typedef std::shared_ptr<Coroutine> SPtr;
 
     BBTATTR_FUNC_Ctor_Hidden
@@ -41,6 +38,7 @@ public:
     virtual CoroutineId             GetId() override;
     CoroutineStatus                 GetStatus();
 
+    /* 事件相关 */
     std::shared_ptr<CoPollEvent>    RegistTimeout(int ms);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key, int timeout_ms);
@@ -50,6 +48,7 @@ public:
     std::shared_ptr<CoPollEvent>    RegistFdWriteable(int fd, int timeout_ms);
 
 protected:
+    /* 事件被触发时回调 */
     void                            OnCoPollEvent(int event, int custom_key);
 
 protected:

--- a/bbt/coroutine/detail/Scheduler.cc
+++ b/bbt/coroutine/detail/Scheduler.cc
@@ -113,12 +113,12 @@ void Scheduler::_Run()
         }
 #endif
 
-        int trigger_event = 0;
+        bool actived = false;
         do {
-            trigger_event = g_bbt_poller->PollOnce();
+            actived = g_bbt_poller->PollOnce();
             _FixTimingScan();
             g_bbt_stackpoll->OnUpdate();
-        } while(trigger_event > 0);
+        } while(actived);
         prev_scan_timepoint = prev_scan_timepoint + bbt::clock::ms(g_bbt_coroutine_config->m_cfg_scan_interval_ms);
         std::this_thread::sleep_until(prev_scan_timepoint);
     }

--- a/unit_test/Debug_poller.cc
+++ b/unit_test/Debug_poller.cc
@@ -15,7 +15,7 @@ int main()
     });
 
     printf("[%ld]\n", bbt::clock::now<>().time_since_epoch().count());
-    Assert(event->RegistFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
+    Assert(event->InitFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
     Assert(event->Regist() == 0);
 
     for (int i = 0; i < 100; i++)

--- a/unit_test/Debug_poller.cc
+++ b/unit_test/Debug_poller.cc
@@ -15,7 +15,7 @@ int main()
     });
 
     printf("[%ld]\n", bbt::clock::now<>().time_since_epoch().count());
-    Assert(event->InitTimeoutEvent(1000) == 0);
+    Assert(event->RegistFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
     Assert(event->Regist() == 0);
 
     for (int i = 0; i < 100; i++)

--- a/unit_test/Test_poller.cc
+++ b/unit_test/Test_poller.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(t_poller_timeout_event_single)
         end_ts = bbt::clock::now<>().time_since_epoch().count();
     });
 
-    Assert(event->InitTimeoutEvent(1000) == 0);
+    Assert(event->RegistFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
     Assert(event->Regist() == 0);
 
     while (count != 1)
@@ -32,8 +32,8 @@ BOOST_AUTO_TEST_CASE(t_poller_timeout_event_single)
         CoPoller::GetInstance()->PollOnce();
     }
 
-    BOOST_CHECK_GE(end_ts - begin_ts, 1000);    // 超时时间不能提前
-    BOOST_CHECK_LT(end_ts - begin_ts, 1010);    // 误差
+    BOOST_CHECK_GE(end_ts - begin_ts, 995);    // 超时时间不能提前
+    BOOST_CHECK_LT(end_ts - begin_ts, 1005);    // 误差
 }
 
 // BOOST_AUTO_TEST_CASE(t_poller_timerout_event_multi)

--- a/unit_test/Test_poller.cc
+++ b/unit_test/Test_poller.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(t_poller_timeout_event_single)
         end_ts = bbt::clock::now<>().time_since_epoch().count();
     });
 
-    Assert(event->RegistFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
+    Assert(event->InitFdEvent(-1, bbt::pollevent::EventOpt::TIMEOUT, 1000) == 0);
     Assert(event->Regist() == 0);
 
     while (count != 1)


### PR DESCRIPTION
## 标题

Fixes #25

## 描述

修改了CoPoller实现方式，CoPoller是提供事件通知机制的，因为协程中是尽量不允许因为一些操作阻塞，所以每当协程因为一些原因需要等待，那么就要注册唤醒事件（等待唤醒条件达成），直到条件达成才会被唤醒。所以是很重要的模块。

目前实现是使用了epoll + 自定义事件来实现的。其中epoll来实现系统文件描述符的读写事件，自定义事件是用户态的协程唤醒机制。

为什么替换需要替换为pollevent呢？其一是这个库是使用libevent来实现的，libevent是专业、应用级、轻量的事件驱动库；其二是为了在当前项目后续模块，诸如网络、http、db等模块接入都可以使用libevent + 其他库 + 协程来实现。

## 事件机制实现逻辑

当前协程在执行可能导致线程阻塞的操作时，应该调用到库内部实现非阻塞版本接口，并在这个接口内注册一个事件，并挂起协程。

## 影响

改动影响较大，有以下调整：
- 调整了CoPoller提供接口的方式，原本的Add、Del、Modify删除，新增CreateEvent来创建一个事件对象并返回；
- 新增Event类（事件对象），通过Event类可以注册、取消该事件；
- 删除CoPoller中epoll实现方式；
- 简化CoPollEvent中初始化、注册事件接口。原本的InitFdxxEvent、InitTimeOutEvent全部取消，使用CreateEvent来提供fd、超时事件。
- 删除CoPollEvent中维护epoll事件的对象。因为使用了pollevent，接口更简单同时不需要使用系统原始接口，也不需要管理epoll_event对象的生命期，所以类内部分字段删除掉。
- Corotuine类和CoPollEvent同步调整，也是因为引入pollevent带来的简化。
- Scheduler因为CoPoller修改，带来一些兼容性修改，整体逻辑不变

