### PR TITLE
Yqm-307/issue37

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -321,7 +321,7 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/bin/unit_test/Test_hook",
-            "args": [],
+            "args": ["--log_level=message"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/bin/unit_test/",
             "environment": [],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ option(RELEASE          "开启将开启优化并不生成debug信息，否则�
 option(NEED_BENCHMARK   "开启将生成Benchmark文件"        ON)
 option(NEED_EXAMPLE     "开启将生成example"              ON)              
 option(NEED_TEST        "开启将生成test文件"             ON)      
-option(PROFILE          "开启将启用profile"              ON)       
+option(PROFILE          "开启将启用profile"              OFF)
 
 if (RELEASE)
     set(CMAKE_CXX_FALGS "${CMAKE_CXX_FLAGS} -std=c++17 -O2")

--- a/bbt/coroutine/coroutine.hpp
+++ b/bbt/coroutine/coroutine.hpp
@@ -17,7 +17,7 @@ namespace bbt::coroutine
 detail::CoroutineId GetLocalCoroutineId();
 
 template<class TItem>
-inline typename sync::Chan<TItem>::SPtr MakeChan(size_t max = 65535)
+inline typename sync::Chan<TItem>::SPtr Chan(size_t max = 65535)
 { return std::make_shared<bbt::coroutine::sync::Chan<TItem>>(max); }
 
 }

--- a/bbt/coroutine/coroutine.hpp
+++ b/bbt/coroutine/coroutine.hpp
@@ -16,4 +16,8 @@ namespace bbt::coroutine
 /* 获取当前运行的协程id，0为main线程中获取的id */
 detail::CoroutineId GetLocalCoroutineId();
 
+template<class TItem>
+inline typename sync::Chan<TItem>::SPtr MakeChan(size_t max = 65535)
+{ return std::make_shared<bbt::coroutine::sync::Chan<TItem>>(max); }
+
 }

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -149,7 +149,7 @@ int CoPollEvent::_RegistCustomEvent()
 
 int CoPollEvent::_RegistFdEvent()
 {
-    return m_event->StartListen(m_timeout);
+    return m_event->StartListen((m_timeout < 0 ? 0 : m_timeout));
 }
 
 
@@ -187,6 +187,12 @@ CoPollEventStatus CoPollEvent::GetStatus() const
 {
     return m_run_status;
 }
+
+int CoPollEvent::GetFd() const
+{
+    return m_event->GetSocket();
+}
+
 
 
 }

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -31,6 +31,7 @@ public:
     bool                            IsListening() const;
     bool                            IsFinal() const;
     CoPollEventStatus               GetStatus() const;
+    int                             GetFd() const;
 
     void                            Trigger(short trigger_events);
     /* 初始化后调用Regist注册事件 */

--- a/bbt/coroutine/sync/Chan.hpp
+++ b/bbt/coroutine/sync/Chan.hpp
@@ -2,6 +2,7 @@
 #include <queue>
 #include <mutex>
 #include <atomic>
+#include <bbt/base/templateutil/Noncopyable.hpp>
 #include <bbt/coroutine/detail/Define.hpp>
 #include <bbt/coroutine/detail/Coroutine.hpp>
 #include <bbt/coroutine/sync/interface/IChan.hpp>
@@ -12,10 +13,12 @@ namespace bbt::coroutine::sync
 
 template<class TItem>
 class Chan:
-    public IChan<TItem>
+    public IChan<TItem>,
+    bbt::templateutil::noncopyable
 {
 public:
     typedef TItem ItemType;
+    typedef std::shared_ptr<Chan<ItemType>> SPtr;
 
     Chan(int max_queue_size = 65535);
     ~Chan();

--- a/bbt/coroutine/sync/Chan.hpp
+++ b/bbt/coroutine/sync/Chan.hpp
@@ -18,7 +18,7 @@ class Chan:
 {
 public:
     typedef TItem ItemType;
-    typedef std::shared_ptr<Chan<ItemType>> SPtr;
+    typedef std::shared_ptr<Chan> SPtr;
 
     Chan(int max_queue_size = 65535);
     ~Chan();

--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -182,4 +182,28 @@ int Chan<TItem>::_WaitWithTimeout(int timeout_ms)
     return m_cond->WaitWithTimeout(timeout_ms);
 }
 
+template<class TItem>
+bool operator<<(Chan<TItem> chan, const typename Chan<TItem>::ItemType& item)
+{
+    return (chan.Write(item) == 0);
+}
+
+template<class TItem>
+bool operator>>(Chan<TItem> chan, const typename Chan<TItem>::ItemType& item)
+{
+    return (chan.Read(item) == 0);
+}
+
+template<class TItem>
+bool operator>>(typename Chan<TItem>::SPtr chan, const typename Chan<TItem>::ItemType& item)
+{
+    return (chan->Write(item) == 0);
+}
+
+template<class TItem>
+bool operator<<(typename Chan<TItem>::SPtr chan, const typename Chan<TItem>::ItemType& item)
+{
+    return (chan->Read(item) == 0);
+}
+
 }

--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -183,25 +183,25 @@ int Chan<TItem>::_WaitWithTimeout(int timeout_ms)
 }
 
 template<class TItem>
-bool operator<<(Chan<TItem> chan, const typename Chan<TItem>::ItemType& item)
+bool operator<<(Chan<TItem>& chan, const typename Chan<TItem>::ItemType& item)
 {
     return (chan.Write(item) == 0);
 }
 
 template<class TItem>
-bool operator>>(Chan<TItem> chan, const typename Chan<TItem>::ItemType& item)
+bool operator>>(Chan<TItem>& chan, const typename Chan<TItem>::ItemType& item)
 {
     return (chan.Read(item) == 0);
 }
 
 template<class TItem>
-bool operator>>(typename Chan<TItem>::SPtr chan, const typename Chan<TItem>::ItemType& item)
+bool operator>>(typename Chan<TItem>::SPtr& chan, const TItem& item)
 {
     return (chan->Write(item) == 0);
 }
 
 template<class TItem>
-bool operator<<(typename Chan<TItem>::SPtr chan, const typename Chan<TItem>::ItemType& item)
+bool operator<<(typename Chan<TItem>::SPtr& chan, TItem& item)
 {
     return (chan->Read(item) == 0);
 }

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -4,7 +4,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g")
 
 enable_testing()
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin/unit_test)
-# add_definitions(-DBBT_COROUTINE_PROFILE)
 
 set(MY_LIBS
     libboost_unit_test_framework.so

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g")
 
 enable_testing()
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin/unit_test)
-add_definitions(-DBBT_COROUTINE_PROFILE)
+# add_definitions(-DBBT_COROUTINE_PROFILE)
 
 set(MY_LIBS
     libboost_unit_test_framework.so

--- a/unit_test/Test_chan.cc
+++ b/unit_test/Test_chan.cc
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(t_chan_operator_overload)
 
     bbtco [&count, wait_ms, &l] () {
         bool succ = false;
-        auto chan = MakeChan<int>();
+        auto chan = Chan<int>();
         int write_val = 1;
         succ = chan << write_val;
         BOOST_ASSERT(succ);

--- a/unit_test/Test_chan.cc
+++ b/unit_test/Test_chan.cc
@@ -3,6 +3,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include <iostream>
+#include <bbt/base/thread/Lock.hpp>
 #include <bbt/base/clock/Clock.hpp>
 #include <bbt/coroutine/coroutine.hpp>
 #include <bbt/coroutine/sync/Chan.hpp>
@@ -65,6 +66,39 @@ BOOST_AUTO_TEST_CASE(t_chan_1_vs_n)
         sleep(5);
         BOOST_CHECK_EQUAL(count.load(), 100 * 1000);
     // }
+
+    g_scheduler->Stop();
+}
+
+BOOST_AUTO_TEST_CASE(t_chan_operator_overload)
+{
+    g_scheduler->Start(true);
+
+    std::atomic_int count = 0;
+    int wait_ms = 100;
+    bbt::thread::CountDownLatch l{1};
+
+    bbtco [&count, wait_ms, &l] () {
+        bool succ = false;
+        auto chan = MakeChan<int>();
+        int write_val = 1;
+        succ = chan << write_val;
+        BOOST_ASSERT(succ);
+
+        int val = 0;
+        succ = chan >> val;
+        BOOST_ASSERT(succ);
+        BOOST_ASSERT(val == 1);
+
+        auto begin = bbt::clock::gettime();
+        succ = chan->TryRead(val, wait_ms);
+        auto end = bbt::clock::gettime();
+        BOOST_ASSERT(!succ);
+        BOOST_ASSERT(end - begin >= wait_ms);
+        l.Down();
+    };
+
+    l.Wait();
 
     g_scheduler->Stop();
 }

--- a/unit_test/Test_cond.cc
+++ b/unit_test/Test_cond.cc
@@ -11,49 +11,13 @@ using namespace bbt::coroutine;
 
 BOOST_AUTO_TEST_SUITE(CoCondTest)
 
-BOOST_AUTO_TEST_CASE(t_cond)
+BOOST_AUTO_TEST_CASE(t_begin)
 {
-    // const int n_max_notify_count = 500;
-    // std::atomic_int ncount = 0;
-    // uint64_t n_begin_time = bbt::clock::now<>().time_since_epoch().count();
-    // uint64_t n_last_time = 0;
-    // g_scheduler->Start(true);
-
-    // bbtco [&]() {
-    //     auto cond = sync::CoCond::Create();
-    //     Assert(cond != nullptr);
-    //     for (int i = 0; i < n_max_notify_count; ++i) {
-    //         g_scheduler->RegistCoroutineTask([i, cond, &n_last_time, &ncount](){
-    //             bbtco_sleep(10);
-    //             Assert(cond->Notify() == 0);
-    //             printf("[%d] now: %ld diff: %ld\n", i, bbt::clock::now<>().time_since_epoch().count(), bbt::clock::now<>().time_since_epoch().count() - n_last_time);
-    //             n_last_time = bbt::clock::now<>().time_since_epoch().count();
-    //             ncount++;
-    //         });
-    //         Assert(cond->Wait() == 0);
-    //     }
-    // };
-
-    // // 非阻塞情况下程序最多活10s
-    // auto max_end_ts = bbt::clock::nowAfter(bbt::clock::seconds(10));
-
-    // /* 开始轮询，探测完成的事件并回调通知到协程事件完成 */
-    // while (ncount.load() != n_max_notify_count && !bbt::clock::is_expired<bbt::clock::milliseconds>(max_end_ts))
-    // {
-    //     std::this_thread::sleep_for(bbt::clock::milliseconds(10));
-    // }
-
-    // printf("begin time: %ld\n", n_begin_time);
-    // printf("end   time: %ld\n", n_last_time);
-    // BOOST_CHECK_EQUAL(ncount.load(), n_max_notify_count);
-
-    // g_scheduler->Stop();
+    g_scheduler->Start(true);
 }
 
 BOOST_AUTO_TEST_CASE(t_cond_multi)
 {
-    g_scheduler->Start(true);
-
     bbtco [](){
         auto co1 = sync::CoCond::Create();
         auto co2 = sync::CoCond::Create();
@@ -84,6 +48,33 @@ BOOST_AUTO_TEST_CASE(t_cond_multi)
         std::this_thread::sleep_for(bbt::clock::milliseconds(10));
     }
 
+}
+
+BOOST_AUTO_TEST_CASE(t_cond_wait_with_timeout)
+{
+    const int wait_ms = 200;
+    uint64_t begin = 0;
+    uint64_t end = 0;
+    bbtco [&](){
+        auto cond = sync::CoCond::Create();
+        begin = bbt::clock::gettime();
+        cond->WaitWithTimeout(wait_ms);
+        end = bbt::clock::gettime();
+    };
+
+    // 非阻塞情况下程序最多活1s
+    auto max_end_ts = bbt::clock::nowAfter(bbt::clock::seconds(1));
+
+    /* 开始轮询，探测完成的事件并回调通知到协程事件完成 */
+    while (!bbt::clock::is_expired<bbt::clock::milliseconds>(max_end_ts))
+    {
+        std::this_thread::sleep_for(bbt::clock::milliseconds(10));
+    }
+    BOOST_CHECK_MESSAGE((end - begin) >= wait_ms, "begin=" << begin << "\tend=" << end << "\twait=" << wait_ms);
+}
+
+BOOST_AUTO_TEST_CASE(t_end)
+{
     g_scheduler->Stop();
 }
 

--- a/unit_test/Test_hook.cc
+++ b/unit_test/Test_hook.cc
@@ -72,21 +72,26 @@ BOOST_AUTO_TEST_CASE(t_hook_write)
 
     bbtco[&l]()
     {
+        BOOST_TEST_MESSAGE("[server] server co=" << bbt::coroutine::GetLocalCoroutineId());
         int fd = bbt::net::Util::CreateListen("", 10001, true);
         BOOST_ASSERT(fd >= 0);
+        BOOST_TEST_MESSAGE("[server] create succ listen fd=" << fd);
         sockaddr_in cli_addr;
         char *buf = new char[1024];
         memset(buf, '\0', 1024);
         socklen_t len = sizeof(cli_addr);
+
         int new_fd = ::accept(fd, (sockaddr *)(&cli_addr), &len);
         BOOST_ASSERT(new_fd >= 0);
+        BOOST_TEST_MESSAGE("[server] accept succ new_fd=" << new_fd);
         int read_len = ::read(new_fd, buf, 1024);
         BOOST_CHECK_GT(read_len, 0);
-        BOOST_CHECK_MESSAGE(std::string{msg} == std::string{buf}, "recv" << std::string{buf});
-        BOOST_TEST_MESSAGE("recv" << std::string{buf});
+        BOOST_ASSERT(std::string{msg} == std::string{buf});
+        BOOST_TEST_MESSAGE("[server] recv" << std::string{buf});
         ::close(fd);
         ::close(new_fd);
         l.Down();
+        BOOST_TEST_MESSAGE("[server] exit!");
     };
 
     bbtco[&l]()
@@ -101,10 +106,16 @@ BOOST_AUTO_TEST_CASE(t_hook_write)
         BOOST_ASSERT(fd >= 0);
         int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
         BOOST_CHECK_MESSAGE(ret == 0, "[connect] errno=" << errno << "\tret=" << ret << "\tfd=" << fd);
+        BOOST_ASSERT(ret == 0);
+        BOOST_TEST_MESSAGE("[client] connect succ");
         ret = ::write(fd, msg, strlen(msg));
         BOOST_CHECK_MESSAGE(ret != -1, "[write] errno=" << errno << "\tret=" << ret << "\tfd=" << fd);
+        BOOST_ASSERT(ret != -1);
+        BOOST_TEST_MESSAGE("[client] send succ");
+        ::sleep(1);
         ::close(fd);
         l.Down();
+        BOOST_TEST_MESSAGE("[client] exit!");
     };
 
     l.Wait();

--- a/unit_test/Test_poller.cc
+++ b/unit_test/Test_poller.cc
@@ -33,6 +33,8 @@ BOOST_AUTO_TEST_CASE(t_poller_timeout_event_single)
     while (count != 1)
     {
         CoPoller::GetInstance()->PollOnce();
+        std::this_thread::sleep_for(bbt::clock::milliseconds(1));
+        printf("poll once %ld \n", bbt::clock::gettime());
     }
 
     BOOST_CHECK_GE(end_ts - begin_ts, 995);    // 超时时间不能提前
@@ -119,10 +121,10 @@ BOOST_AUTO_TEST_CASE(t_poller_timerout_event_multi_thread)
     std::vector<CoPollEvent::SPtr>  events;
     std::mutex                      events_mutex;
 
-    for (int i = 0; i < 10; ++i)
+    for (int i = 0; i < 2; ++i)
     {
         auto t = new std::thread([&](){
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 5000; ++i)
             {
                 auto co_sptr = Coroutine::Create(4096, [](){}, false);
                 auto event = CoPollEvent::Create(co_sptr, [&count, &m_end_mutex, &m_end_time_map, co_sptr](auto, int, int){


### PR DESCRIPTION
Fixes #37

## 改动
- Chan的创建由函数Chan创建，返回智能指针
- 修复CoPollevent监听超时事件参数传递错误的bug
- Chan添加了移位运算符重载，使用更便捷
- 对poller、cond、chan等几个测试例程进行了优化