### PR TITLE
Yqm-307/issue67

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,26 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "attach example echo client",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/build/bin/example/echo_client",
+            "MIMode": "gdb",
+            "miDebuggerPath": "${workspaceFolder}/.vscode/sudo_gdb.sh",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "example echo server",
             "type": "cppdbg",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,30 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Debug_hook_connect",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/unit_test/Debug_hook_connect",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/unit_test",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "chan fatigue test",
             "type": "cppdbg",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,54 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "example echo server",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/example/echo_server",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/example",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "example echo client",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/example/echo_client",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/example",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "Debug_hook_connect",
             "type": "cppdbg",
             "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,9 +82,9 @@
         ".github/workflows/unit_test.yml"
     ],
     "cmake.configureArgs": [
-        "-DNEED_BENCHMARK=OFF",
+        "-DNEED_BENCHMARK=ON",
         "-DNEED_EXAMPLE=ON",
-        "-DNEED_TEST=OFF",
+        "-DNEED_TEST=ON",
         "-DNEED_DEBUG=OFF",
         "-DPROFILE=ON",
         "-DRELEASE=OFF",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,12 +82,12 @@
         ".github/workflows/unit_test.yml"
     ],
     "cmake.configureArgs": [
-        "-DNEED_BENCHMARK=ON",
+        "-DNEED_BENCHMARK=OFF",
         "-DNEED_EXAMPLE=OFF",
-        "-DNEED_TEST=ON",
-        "-DNEED_DEBUG=OFF",
+        "-DNEED_TEST=OFF",
+        "-DNEED_DEBUG=ON",
         "-DPROFILE=OFF",
         "-DRELEASE=OFF",
-        "-DDEBUG_INFO=OFF",
+        "-DDEBUG_INFO=ON",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,9 +83,9 @@
     ],
     "cmake.configureArgs": [
         "-DNEED_BENCHMARK=OFF",
-        "-DNEED_EXAMPLE=OFF",
+        "-DNEED_EXAMPLE=ON",
         "-DNEED_TEST=OFF",
-        "-DNEED_DEBUG=ON",
+        "-DNEED_DEBUG=OFF",
         "-DPROFILE=OFF",
         "-DRELEASE=OFF",
         "-DDEBUG_INFO=ON",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,7 +86,7 @@
         "-DNEED_EXAMPLE=ON",
         "-DNEED_TEST=OFF",
         "-DNEED_DEBUG=OFF",
-        "-DPROFILE=OFF",
+        "-DPROFILE=ON",
         "-DRELEASE=OFF",
         "-DDEBUG_INFO=ON",
     ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if (PROFILE)
     add_definitions(-DBBT_COROUTINE_PROFILE)
 endif()
 
+if (DEBUG_INFO)
+    add_definitions(-DBBT_COROUTINE_DEBUG_PRINT)
+endif()
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib) 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -64,7 +64,8 @@ void CoPollEvent::Trigger(short trigger_events)
         return;
 
     if (_CannelAllFdEvent() != 0)
-        g_bbt_sys_warn_print;
+        // g_bbt_sys_warn_print;
+        g_bbt_dbgp_full("");
 
     m_run_status = CoPollEventStatus::POLLEVENT_TRIGGER;
 

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -60,7 +60,7 @@ private:
     CoPollEventId                   m_event_id{BBT_COROUTINE_INVALID_COPOLLEVENT_ID};
 
     CoPollEventCallback             m_onevent_callback{nullptr};
-    volatile CoPollEventStatus      m_run_status{CoPollEventStatus::POLLEVENT_DEFAULT};
+    std::atomic_int                 m_run_status{CoPollEventStatus::POLLEVENT_DEFAULT};
 };
 
 }

--- a/bbt/coroutine/detail/Coroutine.cc
+++ b/bbt/coroutine/detail/Coroutine.cc
@@ -169,7 +169,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdReadable(int fd)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE, 0) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE | EventOpt::FINALIZE, 0) != 0)
         return nullptr;
     
     if (m_await_event->Regist() != 0)
@@ -188,7 +188,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdReadable(int fd, int timeout_ms)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE | EventOpt::TIMEOUT, timeout_ms))
+    if (m_await_event->InitFdEvent(fd, EventOpt::READABLE | EventOpt::TIMEOUT | EventOpt::FINALIZE, timeout_ms))
         return nullptr;
 
     if (m_await_event->Regist() != 0)
@@ -207,7 +207,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdWriteable(int fd)
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE, 0) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE | EventOpt::FINALIZE, 0) != 0)
         return nullptr;
     
     if (m_await_event->Regist() != 0)
@@ -226,7 +226,7 @@ std::shared_ptr<CoPollEvent> Coroutine::RegistFdWriteable(int fd, int timeout_ms
         OnCoPollEvent(event, custom_key);
     });
 
-    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE | EventOpt::TIMEOUT, timeout_ms) != 0)
+    if (m_await_event->InitFdEvent(fd, EventOpt::WRITEABLE | EventOpt::TIMEOUT | EventOpt::FINALIZE, timeout_ms) != 0)
         return nullptr;
 
     if (m_await_event->Regist() != 0)
@@ -243,7 +243,7 @@ void Coroutine::OnCoPollEvent(int event, int custom_key)
     m_last_resume_event = event;
 
     g_scheduler->OnActiveCoroutine(shared_from_this());
-    g_bbt_dbgp_full(("[CoEvent:Trigger] trigger_event=" + std::to_string(event) + " id=" + std::to_string(m_await_event->GetId()) + " customkey=" + std::to_string(custom_key)).c_str());
+    g_bbt_dbgp_full(("[CoEvent:Trigger] co=" + std::to_string(GetId()) + " trigger_event=" + std::to_string(event) + " id=" + std::to_string(m_await_event->GetId()) + " customkey=" + std::to_string(custom_key)).c_str());
 
     m_await_event = nullptr;
 }

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -36,20 +36,20 @@ public:
 
     virtual void                    Resume() override;
     virtual void                    Yield() override;
-    virtual void                    YieldWithCallback(const CoroutineOnYieldCallback& cb) override;
+    virtual int                     YieldWithCallback(const CoroutineOnYieldCallback& cb) override;
 
     virtual CoroutineId             GetId() override;
     CoroutineStatus                 GetStatus();
     int                             GetLastResumeEvent();
 
     /* 事件相关 */
-    std::shared_ptr<CoPollEvent>    RegistTimeout(int ms);
+    int                             YieldUntilTimeout(int ms);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key, int timeout_ms);
-    std::shared_ptr<CoPollEvent>    RegistFdReadable(int fd);
-    std::shared_ptr<CoPollEvent>    RegistFdReadable(int fd, int timeout_ms);
-    std::shared_ptr<CoPollEvent>    RegistFdWriteable(int fd);
-    std::shared_ptr<CoPollEvent>    RegistFdWriteable(int fd, int timeout_ms);
+    int                             YieldUntilFdReadable(int fd);
+    int                             YieldUntilFdReadable(int fd, int timeout_ms);
+    int                             YieldUntilFdWriteable(int fd);
+    int                             YieldUntilFdWriteable(int fd, int timeout_ms);
 
 protected:
     /* 事件被触发时回调 */

--- a/bbt/coroutine/detail/Define.hpp
+++ b/bbt/coroutine/detail/Define.hpp
@@ -34,9 +34,6 @@
 
 #define g_bbt_stackpoll             (bbt::coroutine::detail::StackPool::GetInstance())
 
-#define g_bbt_sys_warn_print        (bbt::log::WarnPrint("%s, errno : %d %s", __FUNCTION__, errno, strerror(errno)))
-#define g_bbt_warn_print(msg)       (bbt::log::WarnPrint("%s, errno : %d %s, %s", __FUNCTION__, errno, strerror(errno), msg))
-
 namespace bbt::coroutine::sync
 {
 

--- a/bbt/coroutine/detail/Define.hpp
+++ b/bbt/coroutine/detail/Define.hpp
@@ -102,7 +102,7 @@ typedef uint64_t CoPollEventId;
 
 typedef std::function<void()> CoroutineCallback;        // 协程处理主函数
 typedef std::function<void()> CoroutineFinalCallback;   // 协程主函数执行完毕回调
-typedef std::function<void()> CoroutineOnYieldCallback; // 协程挂起后执行回调
+typedef std::function<bool()> CoroutineOnYieldCallback; // 协程挂起后执行回调
 
 /**
  * @param 触发的事件

--- a/bbt/coroutine/detail/Hook.cc
+++ b/bbt/coroutine/detail/Hook.cc
@@ -73,7 +73,6 @@ namespace bbt::coroutine::detail
             if (g_bbt_tls_coroutine_co->YieldUntilFdReadable(fd) != 0)
                 return -1;
 
-            printf("hook read break point\n");
         }
 
         return read_len;

--- a/bbt/coroutine/detail/Hook.cc
+++ b/bbt/coroutine/detail/Hook.cc
@@ -36,12 +36,8 @@ namespace bbt::coroutine::detail
             if (errno != EINTR && errno != EINPROGRESS && errno != EALREADY)
                 return -1;
 
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdWriteable(socket);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdWriteable(socket) != 0)
                 return -1;
-
-            current_run_co->Yield();
         }
 
         return 0;
@@ -57,17 +53,7 @@ namespace bbt::coroutine::detail
         if (ms <= 0)
             return -1;
 
-        errno = EINVAL;
-
-        /* 注册到全局轮询器中监听，并挂起协程 */
-        auto current_run_co = g_bbt_tls_coroutine_co;
-        auto &poller = g_bbt_poller;
-        auto event = current_run_co->RegistTimeout(ms);
-        if (event == nullptr)
-            return -1;
-
-        current_run_co->Yield();
-        return 0;
+        return g_bbt_tls_coroutine_co->YieldUntilTimeout(ms);
     }
 
     ssize_t Hook_Read(int fd, void *buf, size_t nbytes)
@@ -84,12 +70,10 @@ namespace bbt::coroutine::detail
                 return -1;
 
             /* 对当前协程注册fd可读事件，挂起当前协程直到fd可读 */
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdReadable(fd);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdReadable(fd) != 0)
                 return -1;
 
-            current_run_co->Yield();
+            printf("hook read break point\n");
         }
 
         return read_len;
@@ -105,13 +89,8 @@ namespace bbt::coroutine::detail
                 return -1;
 
             /* 对当前协程注册fd可写事件，挂起当前协程直到fd可写 */
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdWriteable(fd);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdWriteable(fd) != 0)
                 return -1;
-
-            /* 挂起直到fd可写 */
-            current_run_co->Yield();
         }
 
         return write_len;
@@ -119,24 +98,20 @@ namespace bbt::coroutine::detail
 
     int Hook_Accept(int fd, struct sockaddr *addr, socklen_t *len)
     {
-        int ret;
+        int new_cli_fd;
 
-        while ((ret = g_bbt_sys_hook_accept_func(fd, addr, len)) < 0)
+        while ((new_cli_fd = g_bbt_sys_hook_accept_func(fd, addr, len)) < 0)
         {
             /* 如果accept没有立即成功，判断失败原因是否为设置非阻塞 */
             if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR)
                 return -1;
 
             /* 对当前协程注册fd可读事件，挂起当前协程直到fd可读 */
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdReadable(fd);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdReadable(fd) != 0)
                 return -1;
-
-            current_run_co->Yield();
         }
 
-        return ret;
+        return new_cli_fd;
     }
 
     ssize_t Hook_Send(int fd, const void *buf, size_t n, int flags)
@@ -149,14 +124,10 @@ namespace bbt::coroutine::detail
                 return -1;
 
             /* 对当前协程注册fd可写事件，挂起当前协程直到fd可写 */
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdWriteable(fd);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdWriteable(fd) != 0)
                 return -1;
-
-            /* 挂起直到fd可写 */
-            current_run_co->Yield();
         }
+
         return send_len;
     }
 
@@ -174,12 +145,8 @@ namespace bbt::coroutine::detail
                 return -1;
 
             /* 对当前协程注册fd可读事件，挂起当前协程直到fd可读 */
-            auto current_run_co = g_bbt_tls_coroutine_co;
-            auto event = current_run_co->RegistFdReadable(fd);
-            if (event == nullptr)
+            if (g_bbt_tls_coroutine_co->YieldUntilFdReadable(fd) != 0)
                 return -1;
-
-            current_run_co->Yield();
         }
 
         return recv_len;

--- a/bbt/coroutine/detail/Hook.cc
+++ b/bbt/coroutine/detail/Hook.cc
@@ -37,7 +37,7 @@ namespace bbt::coroutine::detail
             // sleep(1);
             // g_bbt_sys_hook_sleep_func(1);
             // 是否因为非阻塞导致没法立即完成
-            if (errno != EAGAIN && errno != EINPROGRESS && errno != EINTR)
+            if (errno != EAGAIN && errno != EINPROGRESS && errno != EINTR && errno != EALREADY)
                 return -1;
 
             auto current_run_co = g_bbt_tls_coroutine_co;

--- a/bbt/coroutine/detail/Profiler.cc
+++ b/bbt/coroutine/detail/Profiler.cc
@@ -40,6 +40,16 @@ void Profiler::OnEvent_StartScheudler()
     m_scheduler_begin_timestamp = bbt::clock::now<>();
 }
 
+void Profiler::OnEvent_RegistCoPollEvent()
+{
+    m_regist_event_count++;
+}
+
+void Profiler::OnEvent_TriggerCoPollEvent()
+{
+    m_trigger_event_count++;
+}
+
 void Profiler::OnEvent_StartProcesser(Processer::SPtr proc)
 {
     std::unique_lock<std::mutex> _(m_processer_map_mutex);
@@ -76,6 +86,8 @@ void Profiler::ProfileInfo(std::string& info)
     info += "Steal数量："       + std::to_string(m_total_steal_count.load()) + '\n';
     info += "StackPool大小："   + std::to_string(g_bbt_stackpoll->AllocSize()) + '\n';
     info += "StackPool Rtts："  + std::to_string(g_bbt_stackpoll->GetRtts()) + '\n';
+    info += "CoEvent 注册数量"  + std::to_string(m_regist_event_count.load()) + '\n';
+    info += "CoEvent 触发数量"  + std::to_string(m_trigger_event_count.load()) + '\n';
     for (auto&& processer : m_processer_map)
     {
         info += "\tPID："                    + std::to_string(processer.second->GetId()) +

--- a/bbt/coroutine/detail/Profiler.hpp
+++ b/bbt/coroutine/detail/Profiler.hpp
@@ -30,6 +30,9 @@ public:
     void                        OnEvent_CreateCoroutine();
     void                        OnEvent_DestoryCoroutine();
 
+    void                        OnEvent_RegistCoPollEvent();
+    void                        OnEvent_TriggerCoPollEvent();
+
     void                        OnEvent_StealSucc(int num);
 
     void                        ProfileInfo(std::string& info);
@@ -56,6 +59,10 @@ private:
     std::map<ProcesserId, Processer::SPtr>
                                 m_processer_map;
     std::mutex                  m_processer_map_mutex;
+
+    /* CoEvent 相关指标 */
+    std::atomic_uint64_t        m_regist_event_count{0};
+    std::atomic_uint64_t        m_trigger_event_count{0};
 };
 
 }

--- a/bbt/coroutine/detail/interface/ICoroutine.hpp
+++ b/bbt/coroutine/detail/interface/ICoroutine.hpp
@@ -10,7 +10,7 @@ class ICoroutine
 public:
     virtual void                    Resume() = 0;
     virtual void                    Yield() = 0;
-    virtual void                    YieldWithCallback(const CoroutineOnYieldCallback& cb) = 0;
+    virtual int                     YieldWithCallback(const CoroutineOnYieldCallback& cb) = 0;
 
     virtual CoroutineId             GetId() = 0;
 };

--- a/bbt/coroutine/sync/CoCond.cc
+++ b/bbt/coroutine/sync/CoCond.cc
@@ -51,12 +51,12 @@ int CoCond::Wait()
         m_co_event = current_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
         if (m_co_event == nullptr)
             return -1;
-        
+
         m_run_status = COND_WAIT;
     }
 
     current_co->Yield();
-    
+
     std::unique_lock<std::mutex> _(m_co_event_mutex);
     m_co_event = nullptr;
     m_run_status = COND_FREE;
@@ -82,12 +82,12 @@ int CoCond::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
         m_run_status = COND_WAIT;
     }
 
-    current_co->YieldWithCallback(cb);
+    int ret = current_co->YieldWithCallback(cb);
     
     std::unique_lock<std::mutex> _(m_co_event_mutex);
     m_co_event = nullptr;
     m_run_status = COND_FREE;
-    return 0;
+    return ret;
 }
 
 int CoCond::WaitWithTimeout(int ms)

--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -38,7 +38,7 @@ int Chan<TItem, Max>::Write(const ItemType& item)
     if (m_item_queue.size() >= m_max_size) {
         auto enable_write_cond = _CreateAndPushEnableWriteCond();
 
-        if (_WaitUntilEnableWrite(enable_write_cond, [&](){ lock.unlock(); }) != 0)
+        if (_WaitUntilEnableWrite(enable_write_cond, [&](){ lock.unlock(); return true; }) != 0)
             return -1;
 
         lock.lock();
@@ -336,7 +336,7 @@ int Chan<TItem, 0>::Write(const ItemType& item)
 
     auto enable_write_cond = BaseType::_CreateAndPushEnableWriteCond();
 
-    if (BaseType::_WaitUntilEnableWrite(enable_write_cond, [&](){ lock.unlock(); }) != 0)
+    if (BaseType::_WaitUntilEnableWrite(enable_write_cond, [&](){ lock.unlock(); return true; }) != 0)
         return -1;
     
     return 0;

--- a/bbt/coroutine/utils/DebugPrint.cc
+++ b/bbt/coroutine/utils/DebugPrint.cc
@@ -12,6 +12,7 @@ void VPrint(const char* fmt, ...)
     va_start(args, fmt);
     vfprintf(stdout, fmt, args);
     va_end(args);
+    fflush(stdout);
 #endif
 }
 

--- a/debug/CMakeLists.txt
+++ b/debug/CMakeLists.txt
@@ -36,3 +36,6 @@ target_link_libraries(Debug_steal ${MY_DBG_LIBS})
 
 add_executable(Debug_dbgprintf Debug_dbgprintf.cc)
 target_link_libraries(Debug_dbgprintf ${MY_DBG_LIBS})
+
+add_executable(Debug_hook_connect Debug_hook_connect.cc)
+target_link_libraries(Debug_hook_connect ${MY_DBG_LIBS})

--- a/debug/Debug_hook_connect.cc
+++ b/debug/Debug_hook_connect.cc
@@ -1,0 +1,150 @@
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <bbt/base/net/SocketUtil.hpp>
+#include <bbt/coroutine/coroutine.hpp>
+#include <bbt/coroutine/detail/Hook.hpp>
+#include <bbt/base/clock/Clock.hpp>
+using namespace bbt::coroutine;
+
+#define print(msg) (std::cout << msg << std::endl)
+
+const char *msg = "hello world";
+
+void echo_client(){
+    printf("[client] co=%ld\n", bbt::coroutine::GetLocalCoroutineId());
+
+    sockaddr_in addr;
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    addr.sin_port = htons(10001);
+    addr.sin_family = AF_INET;
+
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    Assert(fd >= 0);
+    print("[client] do connect! fd=" << fd);
+    int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
+    Assert(ret == 0);
+    print("[client] send msg! fd=" << fd);
+    ret = ::write(fd, msg, strlen(msg));
+    Assert(ret != -1);
+    print("[client] exit!");
+    ::close(fd);
+}
+
+void echo_server(){
+    printf("[server] co=%ld\n", bbt::coroutine::GetLocalCoroutineId());
+
+    int fd = bbt::net::Util::CreateListen("", 10001, true);
+    Assert(fd >= 0);
+
+    printf("[server] listenfd=%d\n", fd);
+
+    sockaddr_in cli_addr;
+    char *buf = new char[1024];
+    memset(buf, '\0', 1024);
+    socklen_t len = sizeof(cli_addr);
+
+    while (1)
+    {
+        int new_fd = ::accept(fd, (sockaddr *)(&cli_addr), &len);
+        Assert(new_fd >= 0);
+
+        Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+
+        printf("[server] read msg! fd=%d\n", new_fd);
+
+        int read_len = ::read(new_fd, buf, 1024);
+        Assert(read_len != 0);
+
+        Assert(std::string{msg} == std::string{buf});
+        print("[server] exit!");
+        ::close(new_fd);
+    }
+    ::close(fd);
+}
+
+void test()
+{
+    bbt::thread::CountDownLatch l{2};
+
+    bbtco[&l]()
+    {
+        print("[server] server co=" << bbt::coroutine::GetLocalCoroutineId());
+        int fd = bbt::net::Util::CreateListen("", 10001, true);
+        Assert(fd >= 0);
+        print("[server] create succ listen fd=" << fd);
+        sockaddr_in cli_addr;
+        char *buf = new char[1024];
+        memset(buf, '\0', 1024);
+        socklen_t len = sizeof(cli_addr);
+
+        print("[server] accept start!");
+        int new_fd = ::accept(fd, (sockaddr *)(&cli_addr), &len);
+        Assert(new_fd >= 0);
+
+        Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+        print("[server] read msg! fd=" << new_fd);
+        int read_len = ::read(new_fd, buf, 1024);
+        Assert(read_len != 0);
+
+        Assert(std::string{msg} == std::string{buf});
+        print("[server] recv" << std::string{buf});
+
+        print("[server] exit!");
+        ::close(fd);
+        ::close(new_fd);
+        l.Down();
+    };
+
+    bbtco[&l]()
+    {
+        print("[client] client co=" << bbt::coroutine::GetLocalCoroutineId());
+        ::sleep(1); 
+        sockaddr_in addr;
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+        addr.sin_port = htons(10001);
+        addr.sin_family = AF_INET;
+
+        int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        Assert(fd >= 0);
+        print("[client] connect start! fd=" << fd);
+        int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
+        Assert(ret == 0);
+        // BOOST_CHECK_MESSAGE(ret == 0, "[connect] errno=" << errno << "\tret=" << ret << "\tfd=" << fd);
+        print("[client] send msg to server! fd=" << fd);
+        ret = ::write(fd, msg, strlen(msg));
+        // BOOST_CHECK_MESSAGE(ret != -1, "[write] errno=" << errno << "\tret=" << ret << "\tfd=" << fd);
+        Assert(ret != -1);
+        ::sleep(1);
+
+        print("[client] exit!");
+        ::close(fd);
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+void recurrent()
+{
+    bbtco [](){echo_server();};
+    sleep(1);
+
+    while (1)
+    {
+        std::this_thread::sleep_for(bbt::clock::milliseconds(100));
+        bbtco [](){echo_client();};
+    }    
+}
+
+int main()
+{
+    g_scheduler->Start(true);
+    for (int i = 0;;i++) {
+        printf("================== turn %d ==============\n", i);
+        test();
+    }
+
+    // recurrent();
+    g_scheduler->Stop();
+}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(Wall_Flag "-Wall -Wno-sign-compare -Wno-format -Wno-reorder -Wno-unknown-pragmas")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g -O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g")
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin/example)
 
@@ -12,3 +12,9 @@ target_link_libraries(coroutine ${MY_LIBS})
 
 add_executable(chan chan.cc)
 target_link_libraries(chan ${MY_LIBS})
+
+add_executable(echo_client echoserver/EchoClient.cc)
+target_link_libraries(echo_client ${MY_LIBS})
+
+add_executable(echo_server echoserver/EchoServer.cc)
+target_link_libraries(echo_server ${MY_LIBS})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,3 +18,6 @@ target_link_libraries(echo_client ${MY_LIBS})
 
 add_executable(echo_server echoserver/EchoServer.cc)
 target_link_libraries(echo_server ${MY_LIBS})
+
+add_executable(echo_client_multi echoserver/EchoClientMulti.cc)
+target_link_libraries(echo_client_multi ${MY_LIBS})

--- a/example/echoserver/EchoClient.cc
+++ b/example/echoserver/EchoClient.cc
@@ -6,8 +6,6 @@
 
 using namespace bbt::coroutine;
 
-const char msg[] = "1";
-
 class Client
 {
 public:
@@ -38,15 +36,17 @@ protected:
         int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
         Assert(ret == 0);
         for (int i = 0; i<10000; ++i) {
-            ret = ::write(fd, msg, sizeof(msg));
+            std::string msg = std::to_string(i);
+            ret = ::write(fd, msg.c_str(), sizeof(msg));
+            printf("write\n");
             Assert(ret != -1);
 
             ret = ::read(fd, read_buf, sizeof(read_buf));
+            printf("echo: %s\n", read_buf);
             Assert(ret != -1);
             Assert(ret == sizeof(msg));
         }
 
-        ::sleep(1);
         ::close(fd);
     }
 private:

--- a/example/echoserver/EchoClient.cc
+++ b/example/echoserver/EchoClient.cc
@@ -1,0 +1,65 @@
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <bbt/base/thread/Lock.hpp>
+#include <bbt/coroutine/coroutine.hpp>
+
+using namespace bbt::coroutine;
+
+const char msg[] = "hello world!";
+
+class Client
+{
+public:
+    Client(std::string ip, short port, int round_num):
+        m_ip(ip), m_port(port), m_cdl(round_num), m_round_num(round_num){}
+    ~Client(){}
+
+    void Start() {
+        for (int i = 0; i < m_round_num; ++i) {
+            bbtco [this, i](){
+                _Run();
+                printf("end do once: %d\n", i);
+                m_cdl.Down();
+            };
+        }
+        m_cdl.Wait();
+    }
+
+protected:
+    void _Run() {
+        sockaddr_in addr;
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+        addr.sin_port = htons(10010);
+        addr.sin_family = AF_INET;
+        char read_buf[32];
+        memset(read_buf, '\0', sizeof(read_buf));
+
+        int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        Assert(fd >= 0);
+        int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
+        Assert(ret == 0);
+        ret = ::write(fd, msg, strlen(msg));
+        Assert(ret != -1);
+        printf("[client] send: %s\n", msg);
+
+        ret = ::read(fd, read_buf, sizeof(read_buf));
+        Assert(ret != -1);
+        printf("[client] recv: %s\n", msg);
+        ::close(fd);
+    }
+private:
+    bbt::thread::CountDownLatch m_cdl{1};
+    int m_round_num;
+    std::string m_ip;
+    short       m_port;
+};
+
+int main()
+{
+    g_scheduler->Start(true);
+    Client c{"127.0.0.1", 10010, 10000};
+    c.Start();
+
+    g_scheduler->Stop();
+}

--- a/example/echoserver/EchoClientMulti.cc
+++ b/example/echoserver/EchoClientMulti.cc
@@ -11,21 +11,23 @@ const char msg[] = "1";
 class Client
 {
 public:
-    Client(std::string ip, short port):
-        m_ip(ip), m_port(port), m_cdl(1){}
+    Client(std::string ip, short port, int round_num):
+        m_ip(ip), m_port(port), m_cdl(round_num), m_round_num(round_num){}
     ~Client(){}
 
     void Start() {
-        bbtco [this](){
-            _Run();
-            printf("success\n");
-            m_cdl.Down();
-        };
+        for (int i = 0; i < m_round_num; ++i) {
+            bbtco [this, i](){
+                _Run(i);
+                printf("end do once: %d\n", i);
+                m_cdl.Down();
+            };
+        }
         m_cdl.Wait();
     }
 
 protected:
-    void _Run() {
+    void _Run(int i) {
         sockaddr_in addr;
         addr.sin_addr.s_addr = inet_addr("127.0.0.1");
         addr.sin_port = htons(10010);
@@ -37,20 +39,17 @@ protected:
         Assert(fd >= 0);
         int ret = ::connect(fd, (sockaddr *)(&addr), sizeof(addr));
         Assert(ret == 0);
-        for (int i = 0; i<10000; ++i) {
-            ret = ::write(fd, msg, sizeof(msg));
-            Assert(ret != -1);
+        ret = ::write(fd, std::to_string(i).c_str(), 1);
+        Assert(ret != -1);
 
-            ret = ::read(fd, read_buf, sizeof(read_buf));
-            Assert(ret != -1);
-            Assert(ret == sizeof(msg));
-        }
-
-        ::sleep(1);
+        ret = ::read(fd, read_buf, sizeof(read_buf));
+        Assert(ret != -1);
+        Assert(ret == 1);
         ::close(fd);
     }
 private:
     bbt::thread::CountDownLatch m_cdl{1};
+    int m_round_num;
     std::string m_ip;
     short       m_port;
 };
@@ -58,7 +57,7 @@ private:
 int main()
 {
     g_scheduler->Start(true);
-    Client c{"127.0.0.1", 10010};
+    Client c{"127.0.0.1", 10010, 1000};
     c.Start();
 
     g_scheduler->Stop();

--- a/example/echoserver/EchoServer.cc
+++ b/example/echoserver/EchoServer.cc
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <bbt/base/net/SocketUtil.hpp>
+#include <bbt/base/thread/Lock.hpp>
+#include <bbt/coroutine/coroutine.hpp>
+
+using namespace bbt::coroutine;
+
+class Server
+{
+public:
+    Server(short listen_port):
+        m_listen_port(listen_port){}
+    ~Server(){}
+
+    void Start(){
+        bbtco [this](){
+            _Run();
+            m_cdl.Down();
+        };
+
+        m_cdl.Wait();
+    }
+
+protected:
+    void _Run(){
+        int listen_fd = bbt::net::Util::CreateListen("", m_listen_port, true);
+        Assert(listen_fd >= 0);
+
+        sockaddr_in cli_addr;
+        char *buf = new char[1024];
+        socklen_t len = sizeof(cli_addr);
+
+        while (1)
+        {
+            int new_fd = ::accept(listen_fd, (sockaddr *)(&cli_addr), &len);
+            Assert(new_fd >= 0);
+            memset(buf, '\0', 1024);
+
+            Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+
+            printf("[server] read msg! fd=%d\n", new_fd);
+
+            int read_len = ::read(new_fd, buf, 1024);
+            Assert(read_len > 0);
+            printf("[server] read msg succ! fd=%d msg=%s\n", new_fd, buf);
+            int write_len = ::write(new_fd, buf, read_len);
+            Assert(read_len == write_len);
+            ::close(new_fd);
+        }
+
+        ::close(listen_fd);
+        delete[] buf;
+    }
+private:
+    bbt::thread::CountDownLatch m_cdl{1};
+    short m_listen_port{-1};
+};
+
+int main()
+{
+    g_scheduler->Start(true);
+    Server s{10010};
+    s.Start();
+
+    g_scheduler->Stop();
+}

--- a/example/echoserver/EchoServer.cc
+++ b/example/echoserver/EchoServer.cc
@@ -13,43 +13,52 @@ public:
     ~Server(){}
 
     void Start(){
-        bbtco [this](){
+        // bbtco [this](){
             _Run();
             m_cdl.Down();
-        };
+        // };
 
         m_cdl.Wait();
     }
 
 protected:
     void _Run(){
-        int listen_fd = bbt::net::Util::CreateListen("", m_listen_port, true);
+        int listen_fd = bbt::net::Util::CreateListen("", m_listen_port, false);
+        // int listen_fd = bbt::net::Util::CreateListen("", m_listen_port, true);
         Assert(listen_fd >= 0);
 
         sockaddr_in cli_addr;
-        char *buf = new char[1024];
         socklen_t len = sizeof(cli_addr);
 
         while (1)
         {
+            char buf[2];
             int new_fd = ::accept(listen_fd, (sockaddr *)(&cli_addr), &len);
+            // bbtco [new_fd](){
             Assert(new_fd >= 0);
-            memset(buf, '\0', 1024);
 
-            Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+            // Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
 
-            printf("[server] read msg! fd=%d\n", new_fd);
+            bool noclose = true;
+            while (noclose) {
+                int read_len = ::read(new_fd, buf, 2);
 
-            int read_len = ::read(new_fd, buf, 1024);
-            Assert(read_len > 0);
-            printf("[server] read msg succ! fd=%d msg=%s\n", new_fd, buf);
-            int write_len = ::write(new_fd, buf, read_len);
-            Assert(read_len == write_len);
+                if (read_len == 0)
+                    noclose = false;
+                
+                int write_len = ::write(new_fd, buf, read_len);
+                printf("echo: %s\n", buf);
+                Assert(read_len == write_len);
+
+
+            }
+
             ::close(new_fd);
+            printf("echo done!\n");
+            // };
+            fflush(stdout);
         }
-
         ::close(listen_fd);
-        delete[] buf;
     }
 private:
     bbt::thread::CountDownLatch m_cdl{1};

--- a/example/echoserver/EchoServer.cc
+++ b/example/echoserver/EchoServer.cc
@@ -13,10 +13,10 @@ public:
     ~Server(){}
 
     void Start(){
-        // bbtco [this](){
+        bbtco [this](){
             _Run();
             m_cdl.Down();
-        // };
+        };
 
         m_cdl.Wait();
     }
@@ -32,31 +32,29 @@ protected:
 
         while (1)
         {
-            char buf[2];
             int new_fd = ::accept(listen_fd, (sockaddr *)(&cli_addr), &len);
-            // bbtco [new_fd](){
-            Assert(new_fd >= 0);
+            bbtco [new_fd](){
+                char buf[32];
+                Assert(new_fd >= 0);
 
-            // Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+                // Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
 
-            bool noclose = true;
-            while (noclose) {
-                int read_len = ::read(new_fd, buf, 2);
+                bool close = false;
+                while (!close) {
+                    int read_len = ::read(new_fd, buf, sizeof(buf));
+                    
+                    int write_len = ::write(new_fd, buf, read_len);
 
-                if (read_len == 0)
-                    noclose = false;
-                
-                int write_len = ::write(new_fd, buf, read_len);
-                printf("echo: %s\n", buf);
-                Assert(read_len == write_len);
+                    if (read_len <= 0 or write_len <= 0)
+                        close = true;
 
+                    printf("echo: %s\n", buf);
+                }
 
-            }
-
-            ::close(new_fd);
-            printf("echo done!\n");
-            // };
-            fflush(stdout);
+                ::close(new_fd);
+                printf("echo done!\n");
+                fflush(stdout);
+            };
         }
         ::close(listen_fd);
     }


### PR DESCRIPTION
# 影响

1、example 改动，新增echoserver例程；
2、Coroutine的事件有bug，具体原因和Chan之前遇到的一样，注册pollevent事件和协程挂起前没有加锁，导致协程可能还没挂起就触发了注册的pollevent事件；
3、DebugPrint增加flush，立即输出结果；
4、CoCond、Chan同步Coroutine挂起事件的修改；
5、Hook的函数均同步Coroutine挂起事件的修改。