### PR TITLE
Yqm-307/issue71

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,11 +83,11 @@
     ],
     "cmake.configureArgs": [
         "-DNEED_BENCHMARK=ON",
-        "-DNEED_EXAMPLE=ON",
+        "-DNEED_EXAMPLE=OFF",
         "-DNEED_TEST=ON",
         "-DNEED_DEBUG=OFF",
         "-DPROFILE=ON",
         "-DRELEASE=OFF",
-        "-DDEBUG_INFO=ON",
+        "-DDEBUG_INFO=OFF",
     ]
 }

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -60,14 +60,12 @@ void CoPollEvent::Trigger(short trigger_events)
      * 到底执行什么样的操作了，只由外部创建者定义。
      */
 
-    if (m_run_status != CoPollEventStatus::POLLEVENT_LISTEN)
+    int expect = CoPollEventStatus::POLLEVENT_LISTEN;
+    if (!m_run_status.compare_exchange_strong(expect, CoPollEventStatus::POLLEVENT_TRIGGER))
         return;
 
     if (_CannelAllFdEvent() != 0)
-        // g_bbt_sys_warn_print;
         g_bbt_dbgp_full("");
-
-    m_run_status = CoPollEventStatus::POLLEVENT_TRIGGER;
 
 #ifdef BBT_COROUTINE_PROFILE
     g_bbt_profiler->OnEvent_TriggerCoPollEvent();
@@ -183,8 +181,8 @@ int CoPollEvent::_RegistFdEvent()
 int CoPollEvent::_CannelAllFdEvent()
 {
     int ret = 0;
-    if (m_run_status != CoPollEventStatus::POLLEVENT_LISTEN)
-        return -1;
+    // if (m_run_status != CoPollEventStatus::POLLEVENT_LISTEN)
+        // return -1;
     
     if (m_event != nullptr) {
         m_event = nullptr;

--- a/bbt/coroutine/sync/Chan.hpp
+++ b/bbt/coroutine/sync/Chan.hpp
@@ -124,9 +124,10 @@ protected:
      * @brief 挂起协程直到可写或超时
      * @param cond 挂起事件
      * @param timeout_ms 最大等待的超时时间，超过此时间后即使没有可写数据，阻塞协程也会被唤醒
+     * @param cb 协程挂起后回调
      * @return 0表示可写，-1表示失败，1表示超时
      */
-    int                                     _WaitUntilEnableWriteOrTimeout(CoCond::SPtr cond, int timeout_ms);
+    int                                     _WaitUntilEnableWriteOrTimeout(CoCond::SPtr cond, int timeout_ms, const detail::CoroutineOnYieldCallback& cb = nullptr);
 
     /* 可读事件 */
     int                                     _OnEnableRead();
@@ -139,7 +140,9 @@ protected:
 
     /* 创建一个可写事件 */
     CoCond::SPtr                            _CreateAndPushEnableWriteCond();
-    
+
+    void                                    _Lock();
+    void                                    _UnLock();
 protected:
     const int                               m_max_size{-1};
     std::queue<ItemType>                    m_item_queue;

--- a/bbt/coroutine/sync/Chan.hpp
+++ b/bbt/coroutine/sync/Chan.hpp
@@ -103,14 +103,14 @@ protected:
      * @brief 挂起协程直到可读或者eof
      * @return 0表示可读，-1表示失败 
      */
-    int                                     _WaitUntilEnableRead();
+    int                                     _WaitUntilEnableRead(const detail::CoroutineOnYieldCallback& cb = nullptr);
 
     /**
      * @brief 挂起协程直到可读或超时
      * @param timeout_ms 最大等待的超时时间，超过此时间后即使没有可读数据，阻塞协程也会被唤醒
      * @return 0表示可读，-1表示失败，1表示超时
      */
-    int                                     _WaitUntilEnableReadOrTimeout(int timeout_ms);
+    int                                     _WaitUntilEnableReadOrTimeout(int timeout_ms, const detail::CoroutineOnYieldCallback& cb = nullptr);
 
     /**
      * @brief 挂起协程直到可写

--- a/bbt/coroutine/sync/CoCond.cc
+++ b/bbt/coroutine/sync/CoCond.cc
@@ -12,82 +12,80 @@ namespace bbt::coroutine::sync
 
 using namespace bbt::coroutine::detail;
 
-CoCond::SPtr CoCond::Create()
+CoCond::SPtr CoCond::Create(bool nolock)
 {
-    auto cond = std::make_shared<CoCond>();
-    if (cond->Init() != 0)
-        return nullptr;
-
-    return cond;
+    return std::make_shared<CoCond>(nolock);
 }
 
 
-CoCond::CoCond():
+CoCond::CoCond(bool nolock):
+    m_co_event_mutex(nolock ? nullptr : new std::mutex()),
     m_run_status(COND_FREE)
 {
 }
 
 CoCond::~CoCond()
 {
-}
-
-int CoCond::Init()
-{
-    return 0;
+    if (m_co_event_mutex != nullptr)
+        delete m_co_event_mutex;
 }
 
 int CoCond::Wait()
 {
-    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
+    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
+    AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
 
-    auto current_co = g_bbt_tls_coroutine_co;
-    if (current_co == nullptr)
+    _Lock();
+
+    /* 保证只有一个协程可以成功挂起 */
+    if (m_co_event != nullptr) {
+        _UnLock();
         return -1;
-    {
-        std::unique_lock<std::mutex> _(m_co_event_mutex);
-        if (m_co_event != nullptr)
-            return -1;
-        
-        m_co_event = current_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
-        if (m_co_event == nullptr)
-            return -1;
-
-        m_run_status = COND_WAIT;
     }
 
-    current_co->Yield();
+    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
+    if (m_co_event == nullptr) {
+        _UnLock();
+        return -1;
+    }
 
-    std::unique_lock<std::mutex> _(m_co_event_mutex);
+    m_run_status = COND_WAIT;
+
+    g_bbt_tls_coroutine_co->YieldWithCallback([this](){ _UnLock(); return true; });
+
+    _Lock();
     m_co_event = nullptr;
     m_run_status = COND_FREE;
+    _UnLock();
     return 0;
 }
 
 int CoCond::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
 {
-    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
+    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
+    AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
     Assert(cb != nullptr);
 
-    auto current_co = g_bbt_tls_coroutine_co;
-    if (current_co == nullptr)
+    _Lock();
+    if (m_co_event != nullptr) {
+        _UnLock();
         return -1;
-    {
-        std::unique_lock<std::mutex> _(m_co_event_mutex);
-        if (m_co_event != nullptr)
-            return -1;
-        
-        m_co_event = current_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
-        if (m_co_event == nullptr)
-            return -1;
-        
-        m_run_status = COND_WAIT;
     }
+        
+    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
+    if (m_co_event == nullptr) {
+        _UnLock();
+        return -1;
+    }
+        
+    m_run_status = COND_WAIT;
 
-    int ret = current_co->YieldWithCallback(cb);
-    
-    std::unique_lock<std::mutex> _(m_co_event_mutex);
+    int ret = g_bbt_tls_coroutine_co->YieldWithCallback([this, cb](){ _UnLock(); cb(); return true; });
+
+    _Lock();
     m_co_event = nullptr;
     m_run_status = COND_FREE;
+    _UnLock();
     return ret;
 }
 
@@ -95,31 +93,32 @@ int CoCond::WaitWithTimeout(int ms)
 {
     int ret = 0;
 
-    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
-    
-    auto current_co = g_bbt_tls_coroutine_co;
-    if (current_co == nullptr)
+    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
+    AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
+
+    _Lock();
+    if (m_co_event != nullptr) {
+        _UnLock();
         return -1;
-    {
-        std::unique_lock<std::mutex> _(m_co_event_mutex);
-        if (m_co_event != nullptr)
-            return -1;
-        
-        m_co_event = current_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
-        if (m_co_event == nullptr)
-            return -1;
-        
-        m_run_status = COND_WAIT;
     }
 
-    current_co->Yield();
+    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
+    if (m_co_event == nullptr) {
+        _UnLock();
+        return -1;
+    }
+    
+    m_run_status = COND_WAIT;
 
-    if (current_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
+    ret = g_bbt_tls_coroutine_co->YieldWithCallback([this](){ _UnLock(); return true; });
+
+    if (g_bbt_tls_coroutine_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
         ret = 1;
 
-    std::unique_lock<std::mutex> _(m_co_event_mutex);
+    _Lock();
     m_co_event = nullptr;
     m_run_status = COND_FREE;
+    _UnLock();
     return ret;
 }
 
@@ -127,31 +126,32 @@ int CoCond::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldCal
 {
     int ret = 0;
 
-    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
+    AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
+    AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
 
-    auto current_co = g_bbt_tls_coroutine_co;
-    if (current_co == nullptr)
+    _Lock();
+    if (m_co_event != nullptr) {
+        _UnLock();
         return -1;
-    {
-        std::unique_lock<std::mutex> _(m_co_event_mutex);
-        if (m_co_event != nullptr)
-            return -1;
-
-        m_co_event = current_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
-        if (m_co_event == nullptr)
-            return -1;
-        
-        m_run_status = COND_WAIT;
     }
 
-    ret = current_co->YieldWithCallback(cb);
+    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
+    if (m_co_event == nullptr) {
+        _UnLock();
+        return -1;
+    }
 
-    if (ret == 0 && current_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
+    m_run_status = COND_WAIT;
+
+    ret = g_bbt_tls_coroutine_co->YieldWithCallback([this, cb](){ _UnLock(); cb(); return true; });
+
+    if (ret == 0 && g_bbt_tls_coroutine_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
         ret = 1;
     
-    std::unique_lock<std::mutex> _(m_co_event_mutex);
+    _Lock();
     m_co_event = nullptr;
     m_run_status = COND_FREE;
+    _UnLock();
     return ret;
 }
 
@@ -159,16 +159,31 @@ int CoCond::Notify()
 {
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
 
-    std::unique_lock<std::mutex> _(m_co_event_mutex);
-
+    _Lock();
     Assert(m_run_status != COND_DEFAULT);;
-    if (m_co_event == nullptr || m_run_status != COND_WAIT)
+    if (m_co_event == nullptr || m_run_status != COND_WAIT) {
+        _UnLock();
         return -1;
-    
+    }
+
     m_run_status = COND_ACTIVE;
     g_bbt_poller->NotifyCustomEvent(m_co_event);
 
+    _UnLock();
     return 0;
 }
+
+void CoCond::_Lock()
+{
+    if (m_co_event_mutex != nullptr)
+        m_co_event_mutex->lock();
+}
+
+void CoCond::_UnLock()
+{
+    if (m_co_event_mutex != nullptr)
+        m_co_event_mutex->unlock();
+}
+
 
 }

--- a/bbt/coroutine/sync/CoCond.hpp
+++ b/bbt/coroutine/sync/CoCond.hpp
@@ -10,9 +10,15 @@ class CoCond:
 {
 public:
     typedef std::shared_ptr<CoCond> SPtr;
-    static SPtr                         Create();
+    static SPtr                         Create(bool nolock = false);
 
-    BBTATTR_FUNC_Ctor_Hidden            CoCond();
+    /**
+     * @brief 
+     * 
+     * @param nolock 如果使用无锁版本，请使用WaitWithCallback系列函数，由外部加锁，通过callback解锁
+     * @return BBTATTR_FUNC_Ctor_Hidden 
+     */
+    BBTATTR_FUNC_Ctor_Hidden            CoCond(bool nolock);
                                         ~CoCond();
 
     /**
@@ -55,11 +61,11 @@ public:
      */
     int                                 Notify();
 protected:
-    int                                 Init();
+    void                                _Lock();
+    void                                _UnLock();
 protected:
     std::shared_ptr<detail::CoPollEvent> m_co_event{nullptr};
-    int                                 m_await_co_num{};
-    std::mutex                          m_co_event_mutex;
+    std::mutex*                         m_co_event_mutex{nullptr};
     volatile CoCondStatus               m_run_status{COND_DEFAULT};
 };
 

--- a/bbt/coroutine/sync/CoCond.hpp
+++ b/bbt/coroutine/sync/CoCond.hpp
@@ -40,6 +40,15 @@ public:
     int                                 WaitWithTimeout(int ms);
 
     /**
+     * @brief 挂起当前协程，直到被唤醒或者超时。如果有多个
+     * 调用，只有第一个成功，其余调用者失败
+     * @param ms 
+     * @param cb 
+     * @return int 
+     */
+    int                                 WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldCallback& cb);
+
+    /**
      * @brief 唤醒一个因为调用Wait、WaitWithTimeout而挂起的协程
      *  ，如果没有携程因为Wait相关调用挂起，则Notify会失败
      * @return  0表示成功，-1表示事件已经触发

--- a/benchmark_test/CMakeLists.txt
+++ b/benchmark_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(Wall_Flag "-Wall -Wno-sign-compare -Wno-format -Wno-reorder -Wno-unknown-pragmas")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g -O2")
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin/benchmark_test)
 

--- a/benchmark_test/CMakeLists.txt
+++ b/benchmark_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(Wall_Flag "-Wall -Wno-sign-compare -Wno-format -Wno-reorder -Wno-unknown-pragmas")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g -O2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -std=c++17 ${Wall_Flag} -g")
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin/benchmark_test)
 


### PR DESCRIPTION
# 影响

1、CoPollEvent触发事件时，状态位使用原子变量的cas来实现；

2、CoCond改动
- 支持加锁和无锁版本的，因为考虑到目前使用CoCond来实现上层挂起、唤醒协程时大多会在上层加锁了；
- 支持挂起成功后回调，帮助外部调用者做解锁操作，防止出现挂起、唤醒协程之间的次序问题；

3、Chan修复所有有次序问题的接口