### PR TITLE
Yqm-307/issue74

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,26 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "attach example echo client",
-            "type": "cppdbg",
-            "request": "attach",
-            "program": "${workspaceFolder}/build/bin/example/echo_client",
-            "MIMode": "gdb",
-            "miDebuggerPath": "${workspaceFolder}/.vscode/sudo_gdb.sh",
-            "setupCommands": [
-                {
-                    "description": "为 gdb 启用整齐打印",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "将反汇编风格设置为 Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
-                    "ignoreFailures": true
-                }
-            ]
-        },
-        {
             "name": "example echo server",
             "type": "cppdbg",
             "request": "launch",
@@ -104,6 +84,54 @@
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/bin/benchmark_test",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "fatigue_comutex",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/benchmark_test/fatigue_comutex",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/benchmark_test",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "Test_comutex",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/unit_test/Test_comutex",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/unit_test",
             "environment": [],
             "externalConsole": false,
             "MIMode": "gdb",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,8 +86,8 @@
         "-DNEED_EXAMPLE=OFF",
         "-DNEED_TEST=ON",
         "-DNEED_DEBUG=OFF",
-        "-DPROFILE=ON",
-        "-DRELEASE=OFF",
+        "-DPROFILE=OFF",
+        "-DRELEASE=ON",
         "-DDEBUG_INFO=OFF",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,7 +82,7 @@
         ".github/workflows/unit_test.yml"
     ],
     "cmake.configureArgs": [
-        "-DNEED_BENCHMARK=ON",
+        "-DNEED_BENCHMARK=OFF",
         "-DNEED_EXAMPLE=OFF",
         "-DNEED_TEST=ON",
         "-DNEED_DEBUG=OFF",

--- a/bbt/coroutine/detail/CoPoller.cc
+++ b/bbt/coroutine/detail/CoPoller.cc
@@ -68,6 +68,7 @@ void CoPoller::NotifyCustomEvent(std::shared_ptr<CoPollEvent> event)
 {
     std::unique_lock<std::mutex> _(m_custom_event_active_queue_mutex);
     AssertWithInfo(m_safe_active_set.find(event) == m_safe_active_set.end(), "duplicate registration events! please submit issue!");
+    Assert(event != nullptr);
 
     m_safe_active_set.insert(event);
     m_custom_event_active_queue.push(event);

--- a/bbt/coroutine/detail/Coroutine.cc
+++ b/bbt/coroutine/detail/Coroutine.cc
@@ -60,18 +60,21 @@ Coroutine::~Coroutine()
 
 void Coroutine::Resume()
 {
+    Assert(m_run_status == CoroutineStatus::CO_PENDING || m_run_status == CoroutineStatus::CO_SUSPEND);
     m_run_status = CoroutineStatus::CO_RUNNING;
     m_context.Resume();
 }
 
 void Coroutine::Yield()
 {
+    Assert(m_run_status == CoroutineStatus::CO_RUNNING);
     m_run_status = CoroutineStatus::CO_SUSPEND;
     m_context.Yield();
 }
 
 int Coroutine::YieldWithCallback(const CoroutineOnYieldCallback& cb)
 {
+    Assert(m_run_status == CoroutineStatus::CO_RUNNING);
     m_run_status = CoroutineStatus::CO_SUSPEND;
     return m_context.YieldWithCallback(cb);
 }
@@ -91,12 +94,6 @@ void Coroutine::_OnCoroutineFinal()
     m_run_status = CoroutineStatus::CO_FINAL;
     if (m_co_final_callback)
         m_co_final_callback();
-}
-
-void Coroutine::_OnYield()
-{
-    if (m_co_onyield_callback)
-        m_co_onyield_callback();
 }
 
 int Coroutine::YieldUntilTimeout(int ms)

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -58,7 +58,6 @@ protected:
 protected:
     static CoroutineId              GenCoroutineId();
     void                            _OnCoroutineFinal();
-    void                            _OnYield();
 private:
     Context                         m_context;
     const CoroutineId               m_id{BBT_COROUTINE_INVALID_COROUTINE_ID};

--- a/bbt/coroutine/detail/Define.hpp
+++ b/bbt/coroutine/detail/Define.hpp
@@ -73,6 +73,12 @@ enum CoCondStatus : int32_t
     COND_ACTIVE         = 3,
 };
 
+enum CoMutexStatus
+{
+    COMUTEX_LOCKED      = 0,
+    COMUTEX_FREE        = 1,
+};
+
 }
 
 namespace bbt::coroutine::detail

--- a/bbt/coroutine/sync/CoMutex.cc
+++ b/bbt/coroutine/sync/CoMutex.cc
@@ -111,7 +111,7 @@ void CoMutex::_NotifyOne()
     while (!m_wait_lock_queue.empty()) {
         auto co_sptr = m_wait_lock_queue.front();
         m_wait_lock_queue.pop();
-
+        Assert(co_sptr != nullptr);
         if (co_sptr->Notify() == 0)
             break;
     }

--- a/bbt/coroutine/sync/CoMutex.cc
+++ b/bbt/coroutine/sync/CoMutex.cc
@@ -1,0 +1,50 @@
+#include <bbt/coroutine/sync/CoMutex.hpp>
+
+namespace bbt::coroutine::sync
+{
+
+CoMutex::CoMutex()
+{
+
+}
+
+CoMutex::~CoMutex()
+{
+
+}
+
+void CoMutex::Lock()
+{
+    _Lock();
+
+    /* 如果已经上锁了，挂起并加入到等待队列中 */
+    if (m_status == CoMutexStatus::COMUTEX_LOCKED) {
+        
+    }
+
+    m_status = CoMutexStatus::COMUTEX_LOCKED;
+
+    _UnLock();
+}
+
+void CoMutex::UnLock()
+{
+
+}
+
+int CoMutex::TryLock(int ms)
+{
+
+}
+
+void CoMutex::_Lock()
+{
+    m_mutex.lock();
+}
+
+void CoMutex::_UnLock()
+{
+    m_mutex.unlock();
+}
+
+}

--- a/bbt/coroutine/sync/CoMutex.cc
+++ b/bbt/coroutine/sync/CoMutex.cc
@@ -1,4 +1,5 @@
 #include <bbt/coroutine/sync/CoMutex.hpp>
+#include <bbt/base/assert/Assert.hpp>
 
 namespace bbt::coroutine::sync
 {
@@ -19,22 +20,54 @@ void CoMutex::Lock()
 
     /* 如果已经上锁了，挂起并加入到等待队列中 */
     if (m_status == CoMutexStatus::COMUTEX_LOCKED) {
-        
+        Assert(_WaitUnLock([this](){ _UnLock(); return true; }) == 0);
+
+        _Lock();
     }
 
     m_status = CoMutexStatus::COMUTEX_LOCKED;
-
     _UnLock();
 }
 
 void CoMutex::UnLock()
 {
+    _Lock();
 
+    _NotifyOne();
+
+    _UnLock();
+}
+
+int CoMutex::TryLock()
+{
+
+    int ret = 0;
+    _Lock();
+
+    if (m_status == CoMutexStatus::COMUTEX_FREE)
+        m_status == CoMutexStatus::COMUTEX_LOCKED;
+    else
+        ret = -1;
+
+    _UnLock();
+    return ret;
 }
 
 int CoMutex::TryLock(int ms)
 {
+    int ret = 0;
+    _Lock();
 
+    if (m_status == CoMutexStatus::COMUTEX_LOCKED) {
+        ret = _WaitUnLockUnitlTimeout(ms, [this](){ _UnLock(); return true; });
+
+        _Lock();
+    }
+
+    m_status = CoMutexStatus::COMUTEX_LOCKED;
+    _UnLock();
+
+    return ret;
 }
 
 void CoMutex::_Lock()
@@ -45,6 +78,31 @@ void CoMutex::_Lock()
 void CoMutex::_UnLock()
 {
     m_mutex.unlock();
+}
+
+int CoMutex::_WaitUnLockUnitlTimeout(int timeout, const detail::CoroutineOnYieldCallback& cb)
+{
+    auto co_ptr = CoCond::Create(true);
+    m_wait_lock_queue.push(std::move(co_ptr));
+    return co_ptr->WaitWithTimeoutAndCallback(timeout, std::forward<const detail::CoroutineOnYieldCallback&>(cb));
+}
+
+int CoMutex::_WaitUnLock(const detail::CoroutineOnYieldCallback& cb)
+{
+    auto co_ptr = CoCond::Create(true);
+    m_wait_lock_queue.push(std::move(co_ptr));
+    return co_ptr->WaitWithCallback(std::forward<const detail::CoroutineOnYieldCallback&>(cb));
+}
+
+int CoMutex::_NotifyOne()
+{
+    while (true) {
+        auto co_sptr = m_wait_lock_queue.front();
+        m_wait_lock_queue.pop();
+
+        if (co_sptr->Notify() == 0)
+            break;
+    }
 }
 
 }

--- a/bbt/coroutine/sync/CoMutex.cc
+++ b/bbt/coroutine/sync/CoMutex.cc
@@ -94,14 +94,14 @@ void CoMutex::_SysUnLock()
 
 int CoMutex::_WaitUnLockUnitlTimeout(int timeout, const detail::CoroutineOnYieldCallback& cb)
 {
-    auto co_ptr = CoCond::Create(true);
+    auto co_ptr = CoCond::Create();
     m_wait_lock_queue.push(co_ptr);
     return co_ptr->WaitWithTimeoutAndCallback(timeout, std::forward<const detail::CoroutineOnYieldCallback&>(cb));
 }
 
 int CoMutex::_WaitUnLock(const detail::CoroutineOnYieldCallback& cb)
 {
-    auto co_ptr = CoCond::Create(true);
+    auto co_ptr = CoCond::Create();
     m_wait_lock_queue.push(co_ptr);
     return co_ptr->WaitWithCallback(std::forward<const detail::CoroutineOnYieldCallback&>(cb));
 }

--- a/bbt/coroutine/sync/CoMutex.hpp
+++ b/bbt/coroutine/sync/CoMutex.hpp
@@ -22,21 +22,32 @@ public:
 
     void                        Lock();
     void                        UnLock();
+
+    /**
+     * @brief 获取锁，如果无法立即获取挂起协程直到超时
+     * @param ms 
+     * @return int 0成功，-1发生错误，1表示超时
+     */
     int                         TryLock(int ms);
+
+    /**
+     * @brief 尝试获取锁，立即返回
+     * @return int 0成功，-1表示失败
+     */
     int                         TryLock();
 
 protected:
     int                         _WaitUnLockUnitlTimeout(int timeout, const detail::CoroutineOnYieldCallback& cb);
     int                         _WaitUnLock(const detail::CoroutineOnYieldCallback& cb);
 
-    int                         _NotifyOne();
+    void                        _NotifyOne();
 
-    void                        _Lock();
-    void                        _UnLock();
+    void                        _SysLock();
+    void                        _SysUnLock();
 private:
     std::queue<CoCond::SPtr>    m_wait_lock_queue;
     std::mutex                  m_mutex;
-    CoMutexStatus               m_status{CoMutexStatus::COMUTEX_FREE};
+    volatile CoMutexStatus      m_status{CoMutexStatus::COMUTEX_FREE};
 };
 
 } // bbt::coroutine::sync

--- a/bbt/coroutine/sync/CoMutex.hpp
+++ b/bbt/coroutine/sync/CoMutex.hpp
@@ -13,6 +13,10 @@ namespace bbt::coroutine::sync
  * 协程。
  * 
  * 使用此锁是为了防止阻塞系统线程
+ * 
+ * XXX
+ * 目前实现为使用CoCond来实现。CoCond内部需要加锁导致部
+ * 分锁是重叠的，最好的做法是像CoCond一样控制CoPollEvent
  */
 class CoMutex
 {

--- a/bbt/coroutine/sync/CoMutex.hpp
+++ b/bbt/coroutine/sync/CoMutex.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <bbt/coroutine/detail/Define.hpp>
+#include <bbt/coroutine/sync/CoCond.hpp>
+
+namespace bbt::coroutine::sync
+{
+
+/**
+ * 用来实现协程间的同步
+ * 
+ * 当多个协程有数据竞争时，使用Mutex可以让发生竞争的锁
+ * 挂起等待，当有获取锁的协程解锁后，将唤醒一个竞争中的
+ * 协程。
+ * 
+ * 使用此锁是为了防止阻塞系统线程
+ */
+class CoMutex
+{
+public:
+    CoMutex();
+    ~CoMutex();
+
+    void                        Lock();
+    void                        UnLock();
+    int                         TryLock(int ms);
+
+protected:
+    void                        _Lock();
+    void                        _UnLock();
+private:
+    std::queue<CoCond::SPtr>    m_wait_lock_queue;
+    std::mutex                  m_mutex;
+    CoMutexStatus               m_status{CoMutexStatus::COMUTEX_FREE};
+};
+
+} // bbt::coroutine::sync

--- a/bbt/coroutine/sync/CoMutex.hpp
+++ b/bbt/coroutine/sync/CoMutex.hpp
@@ -23,8 +23,14 @@ public:
     void                        Lock();
     void                        UnLock();
     int                         TryLock(int ms);
+    int                         TryLock();
 
 protected:
+    int                         _WaitUnLockUnitlTimeout(int timeout, const detail::CoroutineOnYieldCallback& cb);
+    int                         _WaitUnLock(const detail::CoroutineOnYieldCallback& cb);
+
+    int                         _NotifyOne();
+
     void                        _Lock();
     void                        _UnLock();
 private:

--- a/bbt/coroutine/sync/RWMutex.hpp
+++ b/bbt/coroutine/sync/RWMutex.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <bbt/coroutine/sync/CoCond.hpp>
+
+namespace bbt::coroutine::sync
+{
+
+class RWMutex
+{
+public:
+
+protected:
+
+
+};
+
+} // bbt::coroutine::sync

--- a/benchmark_test/CMakeLists.txt
+++ b/benchmark_test/CMakeLists.txt
@@ -18,3 +18,6 @@ target_link_libraries(chan_fatigue_test ${MY_LIBS})
 
 add_executable(mem_check_test mem_check_test.cc)
 target_link_libraries(mem_check_test ${MY_LIBS})
+
+add_executable(fatigue_comutex fatigue_comutex.cc)
+target_link_libraries(fatigue_comutex ${MY_LIBS})

--- a/benchmark_test/fatigue_comutex.cc
+++ b/benchmark_test/fatigue_comutex.cc
@@ -1,0 +1,60 @@
+#include <bbt/coroutine/coroutine.hpp>
+#include <bbt/coroutine/sync/CoMutex.hpp>
+
+using namespace bbt::coroutine::sync;
+
+const int nco_num = 100;
+CoMutex mutex;
+volatile int a = 0;
+volatile int b = 0;
+
+void fatigue_1()
+{
+    for (int i = 0; i < nco_num; ++i) {
+        bbtco []() {
+            while (true) {
+                mutex.Lock();
+                Assert(a == b);
+                a++; b++;
+                mutex.UnLock();
+            }
+        };
+    }
+
+    for (int i = 0; i < 5; ++i) {
+        bbtco []() {
+            while (true) {
+                if (mutex.TryLock() == 0) {
+                    Assert(a == b);
+                    a++; b++;
+                    mutex.UnLock();
+                }
+            }            
+        };
+    }
+
+    for (int i = 0; i < 5; ++i) {
+        bbtco []() {
+            while (true) {
+                if (mutex.TryLock(10) == 0) {
+                    Assert(a == b);
+                    a++; b++;
+                    mutex.UnLock();
+                }
+            }
+        };
+    }
+    while(1) {
+        printf("%d %d\n", a, b);
+        sleep(1);
+    }
+}
+
+int main()
+{
+    g_scheduler->Start(true);
+
+    fatigue_1();
+
+    g_scheduler->Stop();
+}

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -37,3 +37,7 @@ add_test(NAME Test_g_co COMMAND Test_g_co)
 add_executable(Test_chan Test_chan.cc)
 target_link_libraries(Test_chan ${MY_LIBS})
 add_test(NAME Test_chan COMMAND Test_chan)
+
+add_executable(Test_comutex Test_comutex.cc)
+target_link_libraries(Test_comutex ${MY_LIBS})
+add_test(NAME Test_comutex COMMAND Test_comutex)

--- a/unit_test/Test_comutex.cc
+++ b/unit_test/Test_comutex.cc
@@ -1,0 +1,86 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/included/unit_test.hpp>
+
+#include <bbt/base/thread/Lock.hpp>
+#include <bbt/coroutine/coroutine.hpp>
+#include <bbt/coroutine/sync/CoMutex.hpp>
+using namespace bbt::coroutine::sync;
+
+BOOST_AUTO_TEST_SUITE(CoMutexTest)
+
+BOOST_AUTO_TEST_CASE(t_scheduler_start)
+{
+    g_scheduler->Start(true);
+}
+
+// 普通加解锁
+BOOST_AUTO_TEST_CASE(t_lock_unlock)
+{
+    CoMutex mutex;
+    const int nco_num = 100;
+    const int nsec = 2000;
+    int a = 0;
+    int b = 0;
+
+
+    const uint64_t begin = bbt::clock::gettime_mono();
+    bbt::thread::CountDownLatch l{nco_num};
+
+    for (int i = 0; i < nco_num; ++i) {
+        bbtco [&mutex, &a, &b, begin, &l]()
+        {
+            while ((bbt::clock::gettime_mono() - begin) < nsec)
+            {
+                mutex.Lock();
+                BOOST_ASSERT(a == b);
+                a++;
+                b++;
+                mutex.UnLock();
+            }
+
+            l.Down();
+        };
+    }
+
+    l.Wait();
+}
+
+// 尝试加解锁
+BOOST_AUTO_TEST_CASE(t_try_lock)
+{
+    CoMutex mutex;
+    const int nco_num = 100;
+    const int nsec = 2000;
+    int a = 0;
+    int b = 0;
+
+    const uint64_t begin = bbt::clock::gettime_mono();
+    bbt::thread::CountDownLatch l{nco_num};
+
+    for (int i = 0; i < nco_num; ++i) {
+        bbtco [&mutex, &a, &b, begin, &l]()
+        {
+            while ((bbt::clock::gettime_mono() - begin) < nsec)
+            {
+                if (mutex.TryLock(1) == 0) {
+                    BOOST_ASSERT(a == b);
+                    a++;
+                    b++;
+                    mutex.UnLock();
+                }
+            }
+
+            l.Down();
+        };
+    }
+
+    l.Wait();
+}
+
+BOOST_AUTO_TEST_CASE(t_scheudler_end)
+{
+    g_scheduler->Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
发现一个问题记录一下：


协程锁-加锁 调用链：
mutex::lock --> cond::wait --> event::regist --> coroutine::Yield


协程锁-解锁 调用链：
mutex::unlock --> cond::notify --> event::trigger --> coroutine::Resume

因为
    1、lock和unlock的调用时机是任意的。
    2、事件触发发生在事件注册后
且，对一个co来说Resume一定要在Yield之后（协程运行的唯一性）
所以，会出现如下情况：

mutex::lock --> cond::wait --> event::regist ----|--> coroutine::Yield
                                                 |
                                                 ↓
                                                 event::trigger --> coroutine::Resume

保证挂起后才可以唤醒

解决方案1：

这里加系统锁                                                                            这里解开系统锁
    ↓                                                                                        ↓
mutex::lock --> system::lock --> cond::wait --> event::regist --> coroutine::Yield --> system::unlock

这样保证挂起完成前，不可能挂起。