### PR TITLE
Yqm 307/issue88

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,7 +86,7 @@
         "-DNEED_EXAMPLE=ON",
         "-DNEED_TEST=ON",
         "-DNEED_DEBUG=ON",
-        "-DPROFILE=OFF",
+        "-DPROFILE=ON",
         "-DRELEASE=ON",
         "-DDEBUG_INFO=OFF",
         "-DSTRINGENT_DEBUG=OFF"

--- a/bbt/coroutine/coroutine.hpp
+++ b/bbt/coroutine/coroutine.hpp
@@ -7,7 +7,9 @@
 
 
 #define bbtco bbt::coroutine::_CoHelper()-
+#define bbtco_desc(desc) bbtco
 #define bbtco_sleep(ms) bbt::coroutine::detail::Hook_Sleep(ms)
+#define co_desc(desc_msg)
 
 
 namespace bbt::coroutine

--- a/bbt/coroutine/detail/CoPoller.hpp
+++ b/bbt/coroutine/detail/CoPoller.hpp
@@ -40,13 +40,6 @@ public:
 protected:
 private:
     std::shared_ptr<bbt::pollevent::EventLoop> m_event_loop{nullptr};
-    // int                             m_epoll_fd{-1};
-
-    std::unordered_set<std::shared_ptr<CoPollEvent>>
-                                    m_safe_active_set;              // 保证不重复的事件
-    std::queue<std::shared_ptr<CoPollEvent>>
-                                    m_custom_event_active_queue;    // 自定义事件活跃队列
-    std::mutex                      m_custom_event_active_queue_mutex;
 };
 
 }

--- a/bbt/coroutine/detail/Define.hpp
+++ b/bbt/coroutine/detail/Define.hpp
@@ -42,7 +42,7 @@ namespace bbt::coroutine::sync
 {
 
 template<class TItem, int Max> class Chan;
-class CoCond;
+class CoWaiter;
 
 
 /*

--- a/bbt/coroutine/detail/Scheduler.cc
+++ b/bbt/coroutine/detail/Scheduler.cc
@@ -111,19 +111,20 @@ void Scheduler::_Run()
     while(m_is_running)
     {
         
-#ifdef BBT_COROUTINE_PROFILE
-        if (g_bbt_coroutine_config->m_cfg_profile_printf_ms > 0 &&
-            bbt::clock::is_expired<bbt::clock::milliseconds>((prev_profile_timepoint + bbt::clock::milliseconds(g_bbt_coroutine_config->m_cfg_profile_printf_ms))))
-        {
-            std::string info = "";
-            g_bbt_profiler->ProfileInfo(info);
-            bbt::log::DebugPrint(info.c_str());
-            prev_profile_timepoint = bbt::clock::now<>();
-        }
-#endif
-
         bool actived = false;
         do {
+
+#ifdef BBT_COROUTINE_PROFILE
+            if (g_bbt_coroutine_config->m_cfg_profile_printf_ms > 0 &&
+                bbt::clock::is_expired<bbt::clock::milliseconds>((prev_profile_timepoint + bbt::clock::milliseconds(g_bbt_coroutine_config->m_cfg_profile_printf_ms))))
+            {
+                std::string info = "";
+                g_bbt_profiler->ProfileInfo(info);
+                bbt::log::DebugPrint(info.c_str());
+                prev_profile_timepoint = bbt::clock::now<>();
+            }
+#endif
+
             actived = g_bbt_poller->PollOnce();
             _FixTimingScan();
             g_bbt_stackpoll->OnUpdate();

--- a/bbt/coroutine/sync/Chan.hpp
+++ b/bbt/coroutine/sync/Chan.hpp
@@ -7,7 +7,7 @@
 #include <bbt/coroutine/detail/Define.hpp>
 #include <bbt/coroutine/detail/Coroutine.hpp>
 #include <bbt/coroutine/sync/interface/IChan.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 
 namespace bbt::coroutine::sync
 {
@@ -118,7 +118,7 @@ protected:
      * @param cb   当协程挂起成功后执行的回调事件
      * @return 0表示可写，-1表示失败
      */
-    int                                     _WaitUntilEnableWrite(CoCond::SPtr cond, const detail::CoroutineOnYieldCallback& cb = nullptr);
+    int                                     _WaitUntilEnableWrite(CoWaiter::SPtr cond, const detail::CoroutineOnYieldCallback& cb = nullptr);
 
     /**
      * @brief 挂起协程直到可写或超时
@@ -127,7 +127,7 @@ protected:
      * @param cb 协程挂起后回调
      * @return 0表示可写，-1表示失败，1表示超时
      */
-    int                                     _WaitUntilEnableWriteOrTimeout(CoCond::SPtr cond, int timeout_ms, const detail::CoroutineOnYieldCallback& cb = nullptr);
+    int                                     _WaitUntilEnableWriteOrTimeout(CoWaiter::SPtr cond, int timeout_ms, const detail::CoroutineOnYieldCallback& cb = nullptr);
 
     /* 可读事件 */
     int                                     _OnEnableRead();
@@ -139,7 +139,7 @@ protected:
     int                                     _OnEnableWrite();
 
     /* 创建一个可写事件 */
-    CoCond::SPtr                            _CreateAndPushEnableWriteCond();
+    CoWaiter::SPtr                            _CreateAndPushEnableWriteCond();
 
     void                                    _Lock();
     void                                    _UnLock();
@@ -151,8 +151,8 @@ protected:
     std::atomic_bool                        m_is_reading{false};
 
     /* 用来实现读写时挂起和可读写时唤醒协程 */
-    CoCond::SPtr                            m_enable_read_cond{nullptr};
-    std::queue<CoCond::SPtr>                m_enable_write_conds;
+    CoWaiter::SPtr                            m_enable_read_cond{nullptr};
+    std::queue<CoWaiter::SPtr>                m_enable_write_conds;
 };
 
 

--- a/bbt/coroutine/sync/CoCond.cc
+++ b/bbt/coroutine/sync/CoCond.cc
@@ -1,0 +1,43 @@
+#include <bbt/coroutine/sync/CoCond.hpp>
+
+namespace bbt::coroutine::sync
+{
+
+CoCond::CoCond()
+{
+}
+
+CoCond::~CoCond()
+{
+}
+
+int CoCond::Wait(std::unique_lock<std::mutex> lock)
+{
+}
+
+int CoCond::WaitFor(std::unique_lock<std::mutex> lock, int ms)
+{
+}
+
+void CoCond::NotifyAll()
+{
+    std::unique_lock<std::mutex> _(m_waiter_queue_mtx);
+    while (_NotifyOne() == 0);
+}
+
+void CoCond::NotifyOne()
+{
+    std::unique_lock<std::mutex> _(m_waiter_queue_mtx);
+    _NotifyOne();
+}
+
+int CoCond::_NotifyOne()
+{
+    if (m_waiter_queue.empty())
+        return -1;
+    
+    auto waiter = m_waiter_queue.front();
+    return waiter.Notify();
+}
+
+}

--- a/bbt/coroutine/sync/CoCond.cc
+++ b/bbt/coroutine/sync/CoCond.cc
@@ -1,43 +1,84 @@
 #include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/utils/DebugPrint.hpp>
 
 namespace bbt::coroutine::sync
 {
 
-CoCond::CoCond()
+CoCond::SPtr CoCond::Create(std::mutex& lock)
+{
+    return std::make_shared<CoCond>(lock);
+}
+
+CoCond::CoCond(std::mutex& lock):
+    m_lock_ref(lock)
 {
 }
 
 CoCond::~CoCond()
 {
+    std::unique_lock<std::mutex> lock{m_lock_ref};
+    if (!m_waiter_queue.empty())
+        g_bbt_dbgp_full((std::to_string(m_waiter_queue.size()) + " coroutine maybe have been lost permanently!").c_str());
+    // NotifyAll();
 }
 
-int CoCond::Wait(std::unique_lock<std::mutex> lock)
+int CoCond::Wait()
 {
+    std::unique_lock<std::mutex> lock{m_lock_ref};
+    auto waiter = CoWaiter::Create();
+    m_waiter_queue.push(waiter);
+
+    int ret = waiter->WaitWithCallback([&lock](){
+        lock.unlock();
+        return true;
+    });
+
+    return ret;
 }
 
-int CoCond::WaitFor(std::unique_lock<std::mutex> lock, int ms)
+int CoCond::WaitFor(int ms)
 {
+    std::unique_lock<std::mutex> lock{m_lock_ref};
+    auto waiter = CoWaiter::Create();
+    m_waiter_queue.push(waiter);
+
+    int ret = waiter->WaitWithTimeoutAndCallback(ms, [&lock](){
+        lock.unlock();
+        return true;
+    });
+
+    return ret;
 }
 
 void CoCond::NotifyAll()
 {
-    std::unique_lock<std::mutex> _(m_waiter_queue_mtx);
-    while (_NotifyOne() == 0);
+    std::unique_lock<std::mutex> lock{m_lock_ref};
+    while (!m_waiter_queue.empty())
+        _NotifyOne();
 }
 
 void CoCond::NotifyOne()
 {
-    std::unique_lock<std::mutex> _(m_waiter_queue_mtx);
+    std::unique_lock<std::mutex> lock{m_lock_ref};
     _NotifyOne();
 }
 
 int CoCond::_NotifyOne()
 {
+    int ret = -1;
     if (m_waiter_queue.empty())
-        return -1;
+        return ret;
     
-    auto waiter = m_waiter_queue.front();
-    return waiter.Notify();
+    while (!m_waiter_queue.empty()) {
+        auto waiter = m_waiter_queue.front();
+        m_waiter_queue.pop();
+        if (waiter->Notify() == 0) {
+            ret = 0;
+            break;
+        }
+    }
+
+    return ret;
 }
 
 }

--- a/bbt/coroutine/sync/CoCond.hpp
+++ b/bbt/coroutine/sync/CoCond.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <bbt/coroutine/sync/CoWaiter.hpp>
+
+namespace bbt::coroutine::sync
+{
+
+class CoCond
+{
+public:
+    CoCond();
+    virtual ~CoCond();
+
+    int                         Wait(std::unique_lock<std::mutex> lock);
+
+    int                         WaitFor(std::unique_lock<std::mutex> lock, int ms);
+
+    void                        NotifyOne();
+    void                        NotifyAll();
+protected:
+    int                         _NotifyOne();
+private:
+    std::queue<CoWaiter>        m_waiter_queue;
+    std::mutex                  m_waiter_queue_mtx;
+};
+
+} // namespace bbt::coroutine::sync

--- a/bbt/coroutine/sync/CoCond.hpp
+++ b/bbt/coroutine/sync/CoCond.hpp
@@ -7,20 +7,24 @@ namespace bbt::coroutine::sync
 class CoCond
 {
 public:
-    CoCond();
+    typedef std::shared_ptr<CoCond> SPtr;
+
+    static SPtr Create(std::mutex& lock);
+
+    BBTATTR_FUNC_Ctor_Hidden
+    CoCond(std::mutex& lock);
     virtual ~CoCond();
 
-    int                         Wait(std::unique_lock<std::mutex> lock);
-
-    int                         WaitFor(std::unique_lock<std::mutex> lock, int ms);
+    int                         Wait();
+    int                         WaitFor(int ms);
 
     void                        NotifyOne();
     void                        NotifyAll();
 protected:
     int                         _NotifyOne();
 private:
-    std::queue<CoWaiter>        m_waiter_queue;
-    std::mutex                  m_waiter_queue_mtx;
+    std::queue<std::shared_ptr<CoWaiter>>       m_waiter_queue;
+    std::mutex&                                 m_lock_ref; 
 };
 
 } // namespace bbt::coroutine::sync

--- a/bbt/coroutine/sync/CoMutex.hpp
+++ b/bbt/coroutine/sync/CoMutex.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <bbt/coroutine/detail/Define.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 
 namespace bbt::coroutine::sync
 {

--- a/bbt/coroutine/sync/CoWaiter.cc
+++ b/bbt/coroutine/sync/CoWaiter.cc
@@ -1,6 +1,6 @@
 #include <unistd.h>
 #include <fcntl.h>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 #include <bbt/coroutine/detail/CoPoller.hpp>
 #include <bbt/coroutine/detail/CoPollEvent.hpp>
 #include <bbt/coroutine/detail/Scheduler.hpp>
@@ -12,25 +12,25 @@ namespace bbt::coroutine::sync
 
 using namespace bbt::coroutine::detail;
 
-CoCond::SPtr CoCond::Create(bool nolock)
+CoWaiter::SPtr CoWaiter::Create(bool nolock)
 {
-    return std::make_shared<CoCond>(nolock);
+    return std::make_shared<CoWaiter>(nolock);
 }
 
 
-CoCond::CoCond(bool nolock):
+CoWaiter::CoWaiter(bool nolock):
     m_co_event_mutex(nolock ? nullptr : new std::mutex()),
     m_run_status(COND_FREE)
 {
 }
 
-CoCond::~CoCond()
+CoWaiter::~CoWaiter()
 {
     if (m_co_event_mutex != nullptr)
         delete m_co_event_mutex;
 }
 
-int CoCond::Wait()
+int CoWaiter::Wait()
 {
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
     AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
@@ -64,7 +64,7 @@ int CoCond::Wait()
     return 0;
 }
 
-int CoCond::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
+int CoWaiter::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
 {
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!"); // 请在协程中使用CoCond
     AssertWithInfo(g_bbt_tls_coroutine_co != nullptr, "running a non-corourine!");      // 当前运行的非协程
@@ -98,7 +98,7 @@ int CoCond::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
     return ret;
 }
 
-int CoCond::WaitWithTimeout(int ms)
+int CoWaiter::WaitWithTimeout(int ms)
 {
     int ret = 0;
 
@@ -135,7 +135,7 @@ int CoCond::WaitWithTimeout(int ms)
     return ret;
 }
 
-int CoCond::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldCallback& cb)
+int CoWaiter::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldCallback& cb)
 {
     int ret = 0;
 
@@ -173,7 +173,7 @@ int CoCond::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldCal
     return ret;
 }
 
-int CoCond::Notify()
+int CoWaiter::Notify()
 {
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "please use CoCond in coroutine!");
 
@@ -191,13 +191,13 @@ int CoCond::Notify()
     return 0;
 }
 
-void CoCond::_Lock()
+void CoWaiter::_Lock()
 {
     if (m_co_event_mutex != nullptr)
         m_co_event_mutex->lock();
 }
 
-void CoCond::_UnLock()
+void CoWaiter::_UnLock()
 {
     if (m_co_event_mutex != nullptr)
         m_co_event_mutex->unlock();

--- a/bbt/coroutine/sync/CoWaiter.hpp
+++ b/bbt/coroutine/sync/CoWaiter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <bbt/coroutine/detail/Define.hpp>
-#include <bbt/base/Attribute.hpp>
 
 namespace bbt::coroutine::sync
 {

--- a/bbt/coroutine/sync/CoWaiter.hpp
+++ b/bbt/coroutine/sync/CoWaiter.hpp
@@ -5,11 +5,11 @@
 namespace bbt::coroutine::sync
 {
 
-class CoCond:
-    public std::enable_shared_from_this<CoCond>
+class CoWaiter:
+    public std::enable_shared_from_this<CoWaiter>
 {
 public:
-    typedef std::shared_ptr<CoCond> SPtr;
+    typedef std::shared_ptr<CoWaiter> SPtr;
     static SPtr                         Create(bool nolock = false);
 
     /**
@@ -18,8 +18,8 @@ public:
      * @param nolock 如果使用无锁版本，请使用WaitWithCallback系列函数，由外部加锁，通过callback解锁
      * @return BBTATTR_FUNC_Ctor_Hidden 
      */
-    BBTATTR_FUNC_Ctor_Hidden            CoCond(bool nolock);
-                                        ~CoCond();
+    BBTATTR_FUNC_Ctor_Hidden            CoWaiter(bool nolock);
+                                        ~CoWaiter();
 
     /**
      * @brief 挂起当前协程，直到被唤醒。如果有多个协程调用Wait族函数只有第一个成功

--- a/bbt/coroutine/sync/RWMutex.hpp
+++ b/bbt/coroutine/sync/RWMutex.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 
 namespace bbt::coroutine::sync
 {

--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -13,7 +13,7 @@ namespace bbt::coroutine::sync
 template<class TItem, int Max>
 Chan<TItem, Max>::Chan():
     m_max_size(Max),
-    m_enable_read_cond(CoCond::Create(true))
+    m_enable_read_cond(CoWaiter::Create(true))
 {
     Assert(m_max_size >= 0);
     m_run_status = ChanStatus::CHAN_OPEN;
@@ -246,13 +246,13 @@ int Chan<TItem, Max>::_WaitUntilEnableRead(const detail::CoroutineOnYieldCallbac
 }
 
 template<class TItem, int Max>
-int Chan<TItem, Max>::_WaitUntilEnableWrite(CoCond::SPtr cond, const detail::CoroutineOnYieldCallback& cb)
+int Chan<TItem, Max>::_WaitUntilEnableWrite(CoWaiter::SPtr cond, const detail::CoroutineOnYieldCallback& cb)
 {
     return cond->WaitWithCallback(std::forward<const detail::CoroutineOnYieldCallback&>(cb));
 }
 
 template<class TItem, int Max>
-int Chan<TItem, Max>::_WaitUntilEnableWriteOrTimeout(CoCond::SPtr cond, int timeout_ms, const detail::CoroutineOnYieldCallback& cb)
+int Chan<TItem, Max>::_WaitUntilEnableWriteOrTimeout(CoWaiter::SPtr cond, int timeout_ms, const detail::CoroutineOnYieldCallback& cb)
 {
     return cond->WaitWithTimeoutAndCallback(timeout_ms, cb);
 }
@@ -275,9 +275,9 @@ int Chan<TItem, Max>::_OnEnableWrite()
 }
 
 template<class TItem, int Max>
-CoCond::SPtr Chan<TItem, Max>::_CreateAndPushEnableWriteCond()
+CoWaiter::SPtr Chan<TItem, Max>::_CreateAndPushEnableWriteCond()
 {
-    auto enable_write_cond = CoCond::Create(true);
+    auto enable_write_cond = CoWaiter::Create(true);
     Assert(enable_write_cond != nullptr);
     m_enable_write_conds.push(enable_write_cond);
 

--- a/benchmark_test/benchmark_coroutine.cc
+++ b/benchmark_test/benchmark_coroutine.cc
@@ -1,7 +1,7 @@
 #include <math.h>
 #include <bbt/coroutine/coroutine.hpp>
 #include <bbt/base/clock/Clock.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 
 int main()
 {

--- a/benchmark_test/fatigue_coroutine.cc
+++ b/benchmark_test/fatigue_coroutine.cc
@@ -1,6 +1,6 @@
 #include <bbt/coroutine/coroutine.hpp>
 #include <bbt/base/clock/Clock.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 
 int main()
 {

--- a/debug/Debug_cond.cc
+++ b/debug/Debug_cond.cc
@@ -1,7 +1,7 @@
 #include <atomic>
 #include <bbt/coroutine/coroutine.hpp>
 #include <bbt/base/clock/Clock.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 using namespace bbt::coroutine;
 
 
@@ -21,7 +21,7 @@ void debug_notify()
     bbtco [](){
         PrintTime("t2");
         /* 创建条件变量 */
-        auto cond = sync::CoCond::Create();
+        auto cond = sync::CoWaiter::Create();
         Assert(cond != nullptr);
 
         /* 注册一个coroutine */
@@ -56,7 +56,7 @@ void debug_notify()
 
     bbtco [](){
         PrintTime("p1");
-        auto cond = sync::CoCond::Create();
+        auto cond = sync::CoWaiter::Create();
         Assert(cond != nullptr);
         int ret = cond->WaitWithTimeout(1000);
         PrintTime("p2");
@@ -72,7 +72,7 @@ void debug_notify()
 void dbg_coroutine_wait()
 {
     g_scheduler->Start(true);
-    auto cond = sync::CoCond::Create();
+    auto cond = sync::CoWaiter::Create();
     for (int i = 0; i < 10; ++i)
         bbtco [&](){
             while (true)

--- a/debug/Debug_coorutine_coevent.cc
+++ b/debug/Debug_coorutine_coevent.cc
@@ -5,7 +5,7 @@ using namespace bbt::coroutine;
 // 协程挂起功能是否有问题
 void dbg_coroutine_wait()
 {
-    auto cond = sync::CoCond::Create();
+    auto cond = sync::CoWaiter::Create();
     while (true) {
         for (int i = 0; i < 10000; ++i)
             bbtco [&](){

--- a/unit_test/Test_chan.cc
+++ b/unit_test/Test_chan.cc
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(t_nocache_chan_1v1)
 
     bbtco [&](){
         auto chan = Chan<int, 0>();
-        auto cond = sync::CoCond::Create();
+        auto cond = sync::CoWaiter::Create();
         bbtco [&](){
             detail::Hook_Sleep(100);
             cond->Notify();

--- a/unit_test/Test_cond.cc
+++ b/unit_test/Test_cond.cc
@@ -4,7 +4,7 @@
 
 #include <bbt/coroutine/coroutine.hpp>
 #include <bbt/base/clock/Clock.hpp>
-#include <bbt/coroutine/sync/CoCond.hpp>
+#include <bbt/coroutine/sync/CoWaiter.hpp>
 using namespace bbt::coroutine;
 
 #define PrintTime(flag) printf("标记点=[%s]   协程id=[%ld] 时间戳=[%ld]\n", flag, GetLocalCoroutineId(), bbt::clock::now<>().time_since_epoch().count());
@@ -21,8 +21,8 @@ BOOST_AUTO_TEST_CASE(t_cond_multi)
     std::atomic_bool run_in_co{false};
 
     bbtco [&run_in_co](){
-        auto co1 = sync::CoCond::Create();
-        auto co2 = sync::CoCond::Create();
+        auto co1 = sync::CoWaiter::Create();
+        auto co2 = sync::CoWaiter::Create();
         Assert(co1 != nullptr && co2 != nullptr);
 
         bbtco [&run_in_co, co1, co2](){
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(t_cond_wait_with_timeout)
     const int wait_ms = 200;
     int a = 0;
     bbtco [&](){
-        auto cond = sync::CoCond::Create();
+        auto cond = sync::CoWaiter::Create();
         auto begin = bbt::clock::gettime();
         cond->WaitWithTimeout(wait_ms);
         auto end = bbt::clock::gettime();


### PR DESCRIPTION
#88 Fixed

1、重写CoCond，原本CoCond更改为CoWaiter，新的CoCond更符合cond的定义；
2、优化CoPoller触发自定义事件的时机；
3、测试CoCond并通过debug；
4、优化Profiler打印信息的时机，防止CoPoller太活跃导致卡顿。