### PR TITLE
优化事件相关的锁

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -450,6 +450,30 @@
             ]
         },
         {
+            "name": "benchmark cocond",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/bin/benchmark_test/benchmark_cocond",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/bin/benchmark_test",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "为 gdb 启用整齐打印",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "将反汇编风格设置为 Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "==== unit_test ====",
             "__desc__": "unit test 程序"
         },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,13 +82,13 @@
         ".github/workflows/unit_test.yml"
     ],
     "cmake.configureArgs": [
-        "-DNEED_BENCHMARK=OFF",
-        "-DNEED_EXAMPLE=OFF",
-        "-DNEED_TEST=OFF",
-        "-DNEED_DEBUG=OFF",
+        "-DNEED_BENCHMARK=ON",
+        "-DNEED_EXAMPLE=ON",
+        "-DNEED_TEST=ON",
+        "-DNEED_DEBUG=ON",
         "-DPROFILE=ON",
         "-DRELEASE=ON",
         "-DDEBUG_INFO=OFF",
-        "-DSTRINGENT_DEBUG=OFF"
+        "-DSTRINGENT_DEBUG=OFF",
     ]
 }

--- a/bbt/coroutine/coroutine.cc
+++ b/bbt/coroutine/coroutine.cc
@@ -9,7 +9,7 @@ namespace bbt::coroutine
 
 detail::CoroutineId GetLocalCoroutineId()
 {
-    auto tls_processer = g_bbt_tls_helper->GetProcesser();
+    auto tls_processer = g_bbt_tls_processer;
     if (tls_processer == nullptr)
         return 0;
 

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -135,14 +135,16 @@ int CoPollEvent::Regist()
     g_bbt_dbgmgr->OnEvent_RegistEvent(shared_from_this());
 #endif
 
+    _OnListen();
+
     if (m_event != nullptr && (_RegistFdEvent() != 0)) {
 #ifdef BBT_COROUTINE_STRINGENT_DEBUG
     g_bbt_dbgmgr->OnEvent_TriggerEvent(shared_from_this());
 #endif
+        m_run_status = CoPollEventStatus::POLLEVENT_INITED;
         return -1;
     }
 
-    _OnListen();
     std::string event = m_event == nullptr ? "-1" : std::to_string(m_event->GetEvents());
     g_bbt_dbgp_full(("[CoEvent:Regist] co=" + std::to_string(m_co_id) +
                                      " event=" + event +
@@ -158,7 +160,6 @@ int CoPollEvent::Regist()
 
 void CoPollEvent::_OnListen()
 {
-    int ret = 0;
     m_run_status = CoPollEventStatus::POLLEVENT_LISTEN;
 }
 

--- a/bbt/coroutine/detail/CoPollEvent.hpp
+++ b/bbt/coroutine/detail/CoPollEvent.hpp
@@ -34,10 +34,12 @@ public:
     int                             GetFd() const;
     int64_t                         GetTimeout() const;
 
-    int                             Trigger(short trigger_events);
     /* 初始化后调用Regist注册事件 */
     int                             InitFdEvent(int fd, short events, int timeout);
     int                             InitCustomEvent(int key, void* args);
+
+    /* 注册、触发、反注册都是线程安全的，意味着可以在任意线程执行 */
+    int                             Trigger(short trigger_events);
     int                             Regist();
     int                             UnRegist();
 

--- a/bbt/coroutine/detail/CoPoller.hpp
+++ b/bbt/coroutine/detail/CoPoller.hpp
@@ -34,6 +34,7 @@ public:
     std::shared_ptr<bbt::pollevent::Event> 
                                     CreateEvent(int fd, short events, const bbt::pollevent::OnEventCallback& onevent_cb);
 
+    /* 线程安全的，多次调用仅第一次有效 */
     void                            NotifyCustomEvent(std::shared_ptr<CoPollEvent> event);
     std::shared_ptr<bbt::pollevent::EventLoop>
                                     GetEventLoop() const;

--- a/bbt/coroutine/detail/Context.cc
+++ b/bbt/coroutine/detail/Context.cc
@@ -64,7 +64,7 @@ int Context::YieldWithCallback(const CoroutineOnYieldCallback& cb)
     m_onyield_callback = nullptr;
     m_onyield_callback_result = YieldCheckStatus::NO_CHECK;
 
-    return 0;
+    return ret;
 }
 
 

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -132,7 +132,6 @@ private:
     FollowEventStatus               m_actived_event{DEFAULT}; // 触发的事件
 
     std::shared_ptr<CoPollEvent>    m_await_event{nullptr};
-    std::mutex                      m_await_event_mutex;
 
     CoroutineFinalCallback          m_co_final_callback{nullptr};
     CoroutineOnYieldCallback        m_co_onyield_callback{nullptr};

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -15,10 +15,19 @@ enum FollowEventStatus
 };
 
 /**
- * @brief 协程对象
+ * @brief
+ *
+ * Coroutine是一个协程对象，封装了协程的上下文和状态信息。
  * 
- * 原则上协程对象不允许多线程共享，目前协程对象只能通过全局队列来
- * 在多线程之间传递，这一方式是为了提高访问协程的效率。
+ * Coroutine还提供了常用的挂起、唤醒以及基于事件的挂起和唤醒的功能。 
+ * 
+ * Coroutine使用shared_ptr来控制生命期，其主要目的是为了在使用
+ * 基于EventLoop的调度器中不会被意外释放。减少编写调度器的难度，
+ * 但是目前Scheduler和Processer的实现可以保证一个Coroutine只
+ * 会在一个时刻，被一个Processer访问到，因为所有Coroutine执行都
+ * 在Processer的上下文中进行。
+ * 
+ * TODO ： 不再使用shared_ptr来控制Coroutine的生命周期
  * 
  */
 class Coroutine:
@@ -37,17 +46,69 @@ public:
     static SPtr                     Create(int stack_size, const CoroutineCallback& co_func, bool need_protect = true);
     static SPtr                     Create(int stack_size, const CoroutineCallback& co_func, const CoroutineFinalCallback& co_final_cb, bool need_protect = true);
 
+    /**
+     * @brief 唤醒协程。切换到协程的上下文中执行。
+     */
     virtual void                    Resume() override;
+
+    /**
+     * @brief 挂起协程。保存协程上下文，并回到调用Resume的上下文中
+     */
     virtual void                    Yield() override;
+
+    /**
+     * @brief 挂起协程，并在挂起成功后执行函数
+     * 
+     * 因为协程在Processer中执行，但是EventLoop在Scheduler中运行。
+     * 如果当前Coroutine在挂起前注册事件，可能会导致Scheduler中
+     * 立即触发此事件并将Coroutine放入就绪队列，导致当前Coroutine
+     * 还没被挂起就被唤醒了。
+     * 
+     * 因此这个函数是为了在挂起成功后，保证Event同步操作的。
+     * 
+     * @param cb 在挂起成功后执行的函数
+     * @return int 成功返回0，cb执行失败返回-1
+     */
     virtual int                     YieldWithCallback(const CoroutineOnYieldCallback& cb) override;
     /* 手动挂起co并加入到全局队列中，和事件触发挂起无冲突，因为一个协程内逻辑串行 */
+
+    /**
+     * @brief 挂起协程，并将协程加入到全局就绪队列中去
+     */
     virtual void                    YieldAndPushGCoQueue();
 
     virtual CoroutineId             GetId() override;
     CoroutineStatus                 GetStatus();
     int                             GetLastResumeEvent();
 
-    /* 事件相关 */
+    /**
+     * YieldUnitl事件
+     * 
+     * 这些事件是为了让Coroutine支持事件驱动的挂起和唤醒。
+     * 
+     * 工作原理：
+     * 首先Coroutine只能在Processer中被访问，当Coroutine执行YieldUnitl被挂起时，
+     * Coroutine会被存储在Event中，此时Coroutine就会被挂起了。Processer会继续执
+     * 行其他Coroutine。当Scheduler中发现有Coroutine的等待事件就绪了，就会将对应
+     * 的Coroutine放入到就绪队列中去。Coroutine只能在一个Processer中被访问，所以
+     * Coroutine可以保证事件是唯一的，不会出现同一个Coroutine被多次唤醒的情况。
+     * 
+     *  事件触发有两种情况：
+     *      1、Scheduler中事件就绪了，会将Coroutine放入就绪队列中去；
+     *      2、其他Processer中触发了Custom事件，会将Coroutine放入就绪队列中去。
+     * 
+     * 支持的事件有：
+     * - 可读事件：当fd可读
+     * - 可写事件：当fd可写
+     * - 超时事件：当超过指定时间
+     * - 自定义事件：当自定义事件被触发
+     * 
+     * Q: 事件触发是否为异步的？
+     * A: 是的，首先明确Coroutine只能在Processer中被访问，且YieldUnitl
+     * 只能由当前Coroutine主动调用，那么事件注册的唯一性就可以保证了。
+     * 
+     */
+
     int                             YieldUntilTimeout(int ms);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key);
     std::shared_ptr<CoPollEvent>    RegistCustom(int key, int timeout_ms);

--- a/bbt/coroutine/detail/GlobalConfig.hpp
+++ b/bbt/coroutine/detail/GlobalConfig.hpp
@@ -29,8 +29,8 @@ public:
     const size_t                                m_cfg_profile_printf_ms{1000};              // 打印profile间隔，0不打印
 
     /* Processer */
-    const size_t                                m_cfg_processer_get_co_from_g_count{1};   // 每次从g队列获取任务数量
-    const size_t                                m_cfg_processer_steal_once_min_task_num{64};// 如果有任务，最少偷64个
+    const size_t                                m_cfg_processer_get_co_from_g_count{16};   // 每次从g队列获取任务数量
+    const size_t                                m_cfg_processer_steal_once_min_task_num{8};// 如果有任务，最少偷64个
     const size_t                                m_cfg_processer_worksteal_timeout_ms{10};   // work steal 认为任务饿死的超时时间
     const size_t                                m_cfg_processer_proc_interval_us{3000};     // proc 每次执行间隔时间
 

--- a/bbt/coroutine/detail/GlobalConfig.hpp
+++ b/bbt/coroutine/detail/GlobalConfig.hpp
@@ -29,10 +29,10 @@ public:
     const size_t                                m_cfg_profile_printf_ms{1000};              // 打印profile间隔，0不打印
 
     /* Processer */
-    const size_t                                m_cfg_processer_get_co_from_g_count{256};   // 每次从g队列获取任务数量
+    const size_t                                m_cfg_processer_get_co_from_g_count{1};   // 每次从g队列获取任务数量
     const size_t                                m_cfg_processer_steal_once_min_task_num{64};// 如果有任务，最少偷64个
     const size_t                                m_cfg_processer_worksteal_timeout_ms{10};   // work steal 认为任务饿死的超时时间
-    const size_t                                m_cfg_processer_proc_interval_us{2000};     // proc 每次执行间隔时间
+    const size_t                                m_cfg_processer_proc_interval_us{3000};     // proc 每次执行间隔时间
 
     /* 栈池配置 */
     const size_t                                m_cfg_stackpool_max_alloc_size{1024 * 1000}; // 栈池中分配最大栈数量

--- a/bbt/coroutine/detail/Processer.cc
+++ b/bbt/coroutine/detail/Processer.cc
@@ -216,7 +216,7 @@ void Processer::Steal(std::vector<Coroutine::SPtr>& works)
         if (!m_coroutine_queue.try_dequeue(item))
             break;
 
-        works.push_back(item);
+        works.emplace_back(item);
     }
 
 #ifdef BBT_COROUTINE_PROFILE

--- a/bbt/coroutine/detail/Scheduler.cc
+++ b/bbt/coroutine/detail/Scheduler.cc
@@ -198,7 +198,7 @@ size_t Scheduler::GetGlobalCoroutine(std::vector<Coroutine::SPtr>& coroutines, s
         if (!m_global_coroutine_deque.try_dequeue(item))
             break;
 
-        coroutines.push_back(item);
+        coroutines.emplace_back(item);
     }
 
     return coroutines.size();

--- a/bbt/coroutine/pool/CoPool.cc
+++ b/bbt/coroutine/pool/CoPool.cc
@@ -17,7 +17,7 @@ std::shared_ptr<CoPool> CoPool::Create(int max_co)
 CoPool::CoPool(int max):
     m_max_co_num(max),
     m_latch(m_max_co_num + 1), // monitor co + work co
-    m_cond(sync::CoCond::Create(m_cond_mtx))
+    m_cond(sync::CoCond::Create())
 {
     Assert(m_max_co_num > 0);
     _Start();

--- a/bbt/coroutine/sync/CoCond.hpp
+++ b/bbt/coroutine/sync/CoCond.hpp
@@ -1,30 +1,53 @@
 #pragma once
+#include <bbt/core/thread/sync/Queue.hpp>
 #include <bbt/coroutine/sync/CoWaiter.hpp>
 
 namespace bbt::coroutine::sync
 {
 
-class CoCond
+class CoCond:
+    public std::enable_shared_from_this<CoCond>
 {
 public:
     typedef std::shared_ptr<CoCond> SPtr;
 
-    static SPtr Create(std::mutex& lock);
+    static SPtr Create();
 
     BBTATTR_FUNC_Ctor_Hidden
-    CoCond(std::mutex& lock);
+    CoCond();
     virtual ~CoCond();
 
+    /**
+     * @brief 使当前Coroutine挂起，直到被Notify（只能在Coroutine中使用）
+     * 
+     * @return int 是否成功挂起
+     */
     int                         Wait();
+
+    /**
+     * @brief 使当前Coroutine挂起，直到被Notify或超时（只能在Coroutine中使用）
+     * 
+     * @param ms 超时时间
+     * @return int 是否成功挂起
+     */
     int                         WaitFor(int ms);
 
+    /**
+     * @brief 唤醒一个在此CoCond上挂起的Coroutine
+     * 
+     * @return int 如果有Coroutine被唤醒，返回0；否则返回-1
+     */
     int                         NotifyOne();
+
+    /**
+     * @brief 唤醒所有在此CoCond上挂起的Coroutine
+     * 
+     */
     void                        NotifyAll();
 protected:
     int                         _NotifyOne();
 private:
-    std::queue<std::shared_ptr<CoWaiter>>       m_waiter_queue;
-    std::mutex&                                 m_lock_ref;
+    bbt::core::thread::Queue<CoWaiter*>         m_waiter_queue{8};
 };
 
 } // namespace bbt::coroutine::sync

--- a/bbt/coroutine/sync/CoRWMutex.cc
+++ b/bbt/coroutine/sync/CoRWMutex.cc
@@ -122,14 +122,14 @@ int CoRWMutex::_NotifyAll(bool reader)
 
 int CoRWMutex::_WaitRLock(detail::CoroutineOnYieldCallback&& cb)
 {
-    auto waiter = CoWaiter::Create(true);
+    auto waiter = CoWaiter::Create();
     m_wait_readlock_queue.push(waiter);
     return waiter->WaitWithCallback(std::forward<detail::CoroutineOnYieldCallback&&>(cb));
 }
 
 int CoRWMutex::_WaitWLock(detail::CoroutineOnYieldCallback&& cb)
 {
-    auto waiter = CoWaiter::Create(true);
+    auto waiter = CoWaiter::Create();
     m_wait_writelock_queue.push(waiter);
     return waiter->WaitWithCallback(std::forward<detail::CoroutineOnYieldCallback&&>(cb));
 }

--- a/bbt/coroutine/sync/CoWaiter.hpp
+++ b/bbt/coroutine/sync/CoWaiter.hpp
@@ -4,21 +4,14 @@
 namespace bbt::coroutine::sync
 {
 
-class CoWaiter:
-    public std::enable_shared_from_this<CoWaiter>
+class CoWaiter
 {
 public:
     typedef std::shared_ptr<CoWaiter> SPtr;
-    static SPtr                         Create(bool nolock = false);
+    static SPtr                         Create();
 
-    /**
-     * @brief 
-     * 
-     * @param nolock 如果使用无锁版本，请使用WaitWithCallback系列函数，由外部加锁，通过callback解锁
-     * @return BBTATTR_FUNC_Ctor_Hidden 
-     */
-    BBTATTR_FUNC_Ctor_Hidden            CoWaiter(bool nolock);
-                                        ~CoWaiter();
+    CoWaiter();
+    ~CoWaiter();
 
     /**
      * @brief 挂起当前协程，直到被唤醒。如果有多个协程调用Wait族函数只有第一个成功
@@ -60,11 +53,7 @@ public:
      */
     int                                 Notify();
 protected:
-    void                                _Lock();
-    void                                _UnLock();
-protected:
     std::shared_ptr<detail::CoPollEvent> m_co_event{nullptr};
-    std::mutex*                         m_co_event_mutex{nullptr};
     volatile CoCondStatus               m_run_status{COND_DEFAULT};
 };
 

--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -13,7 +13,7 @@ namespace bbt::coroutine::sync
 template<class TItem, int Max>
 Chan<TItem, Max>::Chan():
     m_max_size(Max),
-    m_enable_read_cond(CoWaiter::Create(true))
+    m_enable_read_cond(CoWaiter::Create())
 {
     Assert(m_max_size >= 0);
     m_run_status = ChanStatus::CHAN_OPEN;
@@ -277,7 +277,7 @@ int Chan<TItem, Max>::_OnEnableWrite()
 template<class TItem, int Max>
 CoWaiter::SPtr Chan<TItem, Max>::_CreateAndPushEnableWriteCond()
 {
-    auto enable_write_cond = CoWaiter::Create(true);
+    auto enable_write_cond = CoWaiter::Create();
     Assert(enable_write_cond != nullptr);
     m_enable_write_conds.push(enable_write_cond);
 

--- a/bbt/coroutine/syntax/SyntaxMacro.hpp
+++ b/bbt/coroutine/syntax/SyntaxMacro.hpp
@@ -28,7 +28,7 @@ do \
 } while(0);
 
 /* sync */
-#define bbtco_make_cocond(mtx)     bbt::coroutine::sync::CoCond::Create(mtx)
+#define bbtco_make_cocond()     bbt::coroutine::sync::CoCond::Create()
 #define bbtco_make_comutex()    bbt::coroutine::sync::CoMutex::Create()
 #define bbtco_make_corwmutex()  bbt::coroutine::sync::CoRWMutex::Create()
 /* copool */

--- a/bbt/coroutine/utils/DebugPrint.hpp
+++ b/bbt/coroutine/utils/DebugPrint.hpp
@@ -7,6 +7,8 @@ namespace bbt::coroutine::utils
 
 void VPrint(const char* fmt, ...);
 
+#ifdef BBT_COROUTINE_DEBUG_PRINT
+
 #define __g_bbt_debug_printf(fmt, ...) \
     bbt::coroutine::utils::VPrint(fmt, ##__VA_ARGS__)
 
@@ -19,4 +21,13 @@ void VPrint(const char* fmt, ...);
 #define g_bbt_dbgp_full(msg) \
     __g_bbt_debug_printf_full(msg)
 
+#endif
+
+#define __g_bbt_debug_printf(fmt, ...)
+
+#define __g_bbt_debug_printf_full(msg)
+
+#define g_bbt_dbgp(module, msg)
+
+#define g_bbt_dbgp_full(msg)
 }

--- a/bbt/coroutine/utils/DebugPrint.hpp
+++ b/bbt/coroutine/utils/DebugPrint.hpp
@@ -21,8 +21,7 @@ void VPrint(const char* fmt, ...);
 #define g_bbt_dbgp_full(msg) \
     __g_bbt_debug_printf_full(msg)
 
-#endif
-
+#else
 #define __g_bbt_debug_printf(fmt, ...)
 
 #define __g_bbt_debug_printf_full(msg)
@@ -30,4 +29,6 @@ void VPrint(const char* fmt, ...);
 #define g_bbt_dbgp(module, msg)
 
 #define g_bbt_dbgp_full(msg)
+#endif
+
 }

--- a/benchmark_test/CMakeLists.txt
+++ b/benchmark_test/CMakeLists.txt
@@ -33,3 +33,6 @@ target_link_libraries(fatigue_std_uniquelock ${MY_LIBS})
 
 add_executable(mem_check_test mem_check_test.cc)
 target_link_libraries(mem_check_test ${MY_LIBS})
+
+add_executable(benchmark_cocond benchmark_cocond.cc)
+target_link_libraries(benchmark_cocond ${MY_LIBS})

--- a/benchmark_test/benchmark_cocond.cc
+++ b/benchmark_test/benchmark_cocond.cc
@@ -1,0 +1,81 @@
+#include <bbt/coroutine/coroutine.hpp>
+
+using CoId = bbt::coroutine::detail::CoroutineId;
+
+int main()
+{
+    const int ncount = 10000;
+    const int time_s = 3600;
+
+
+    std::map<CoId, int> co_sleep_count_map;
+    std::mutex co_sleep_count_map_mutex;
+    std::atomic_int stop_count{0};
+    volatile bool is_stop{false};
+    g_scheduler->Start();
+
+    
+    auto cocond = bbtco_make_cocond();
+
+    for (int i = 0; i < ncount; ++i)
+    {
+        bbtco_desc("这个协程不停的 wait, 在醒来后将自己wait次数加1") [&](){
+            while (true)
+            {
+                cocond->Wait();
+                if (is_stop)
+                {
+                    stop_count++;
+                    break;
+                }
+                std::unique_lock<std::mutex> lock(co_sleep_count_map_mutex);
+                auto it = co_sleep_count_map.find(g_bbt_tls_coroutine_co->GetId());
+                if (it == co_sleep_count_map.end())
+                {
+                    co_sleep_count_map[g_bbt_tls_coroutine_co->GetId()] = 1;
+                }
+                else
+                {
+                    it->second++;
+                }
+            }
+        };
+    }
+
+    bbtco_desc("定时唤醒所有coroutine") [&](){
+        int notify_times = 0;
+        auto now = bbt::core::clock::gettime();
+        while (now + time_s * 1000 > bbt::core::clock::gettime())
+        {
+            bbtco_sleep(200);
+            cocond->NotifyAll();
+            notify_times++;
+            bbtco_sleep(200);
+            std::unique_lock<std::mutex> lock(co_sleep_count_map_mutex);
+
+            for (const auto& [co_id, count] : co_sleep_count_map)
+            {
+                if (count < notify_times)
+                    printf("a bad co! co_id: %d, count: %d\n", co_id, count);
+            }
+
+            printf("notify all once! times: %d\n", notify_times);
+        }
+    };
+
+    bbtco_desc("结束后销毁所有协程") [&](){
+        bbtco_sleep(time_s * 1000);
+        is_stop = true;
+        while (stop_count.load() < ncount)
+        {
+            bbtco_sleep(100);
+            cocond->NotifyAll();
+        }
+    };
+
+
+    // 60s 回收所有资源
+    sleep(time_s + 60);
+
+    g_scheduler->Stop();
+}

--- a/benchmark_test/fatigue_cocond.cc
+++ b/benchmark_test/fatigue_cocond.cc
@@ -6,17 +6,16 @@ int main()
     g_scheduler->Start();
 
     /**
-     * 开启1000个协程不停挂起，在唤醒后标记自己的计数
+     * 开启n个协程不停挂起，在唤醒后标记自己的计数
      * 
      * 开启一个协程定时唤醒，并检查计数
      */
 
     std::array<std::atomic_int, nco> alive_arr{0};
-    std::mutex mutex;
     std::atomic_int current_frame{0};
 
 
-    auto cond = bbtco_make_cocond(mutex);
+    auto cond = bbtco_make_cocond();
 
     for (int i = 0; i < nco; ++i) {
         bbtco [&, i](){

--- a/debug/Debug_bbtcoevent.cc
+++ b/debug/Debug_bbtcoevent.cc
@@ -1,24 +1,34 @@
 #include <bbt/coroutine/coroutine.hpp>
 
+void debug_1()
+{
+    while (true)
+    {
+        bbt::core::thread::CountDownLatch l{1};
+        std::atomic_int i = 0;
+        auto copool = bbtco_make_copool(10);
+    
+        __bbtco_event_regist_with_copool_ex(-1, bbtco_emev_persist, 10, copool)
+        [&](auto, short event){
+            if (++i < 100)
+                return true;
+            
+            l.Down();
+            return false;
+        };
+    
+        l.Wait();
+        copool->Release();
+        assert(i == 100);
+    }
+}
+
 int main()
 {
     g_scheduler->Start();
     std::atomic_int val = 0;
 
-    while (true) {
-        
-        for (int i = 0; i < 10000; ++i) {
-            auto a = bbtco_ev_t(100) [&](int fd, short event){
-                val++;
-                return false;
-            };
-
-            Assert(a == 0);
-        }
-
-        std::this_thread::sleep_for(bbt::core::clock::ms(100));
-        printf("timenow:%ld ncount:%d\n", time(NULL), val.load());
-    }
+    debug_1();
 
     g_scheduler->Stop();
 }

--- a/debug/Debug_cond.cc
+++ b/debug/Debug_cond.cc
@@ -93,12 +93,11 @@ void dbg_coroutine_wait()
 
 void cocond()
 {
-    std::mutex lock;
     bbt::core::thread::CountDownLatch l{1};
     bbt::core::thread::CountDownLatch l2{1};
 
     bbtco [&](){
-        auto cond = sync::CoCond::Create(lock);
+        auto cond = sync::CoCond::Create();
 
         bbtco [&](){
             cond->Wait();
@@ -117,7 +116,6 @@ void cocond()
 
 void multi_cond_check()
 {
-    std::mutex lock;
     const int nmax_wait_co = 1000;
     bbt::core::thread::CountDownLatch l1{1};
     bbt::core::thread::CountDownLatch l2{1};
@@ -127,7 +125,7 @@ void multi_cond_check()
         l2.Reset(1);
         std::atomic_int wait_count{0};
         bbtco [&, i](){
-            auto cond = sync::CoCond::Create(lock);
+            auto cond = sync::CoCond::Create();
 
             for (int i = 0; i < nmax_wait_co; ++i) {
                 bbtco [&](){
@@ -152,9 +150,8 @@ void multi_cond_check()
 
 void consumer_producer()
 {
-    std::mutex lock;
     bbtco [&](){
-        auto cond = sync::CoCond::Create(lock);
+        auto cond = sync::CoCond::Create();
 
         bbtco_desc("this is consumer co!") 
         [&](){

--- a/debug/Debug_hook_connect.cc
+++ b/debug/Debug_hook_connect.cc
@@ -34,7 +34,7 @@ void echo_client(){
 void echo_server(){
     printf("[server] co=%ld\n", bbt::coroutine::GetLocalCoroutineId());
 
-    int fd = bbt::net::Util::CreateListen("", 10001, true);
+    int fd = bbt::core::net::Util::CreateListen("", 10001, true);
     Assert(fd >= 0);
 
     printf("[server] listenfd=%d\n", fd);
@@ -49,7 +49,7 @@ void echo_server(){
         int new_fd = ::accept(fd, (sockaddr *)(&cli_addr), &len);
         Assert(new_fd >= 0);
 
-        Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+        Assert(bbt::core::net::Util::SetFdNoBlock(new_fd) == 0);
 
         printf("[server] read msg! fd=%d\n", new_fd);
 
@@ -70,7 +70,7 @@ void test()
     bbtco[&l]()
     {
         print("[server] server co=" << bbt::coroutine::GetLocalCoroutineId());
-        int fd = bbt::net::Util::CreateListen("", 10001, true);
+        int fd = bbt::core::net::Util::CreateListen("", 10001, true);
         Assert(fd >= 0);
         print("[server] create succ listen fd=" << fd);
         sockaddr_in cli_addr;
@@ -82,7 +82,7 @@ void test()
         int new_fd = ::accept(fd, (sockaddr *)(&cli_addr), &len);
         Assert(new_fd >= 0);
 
-        Assert(bbt::net::Util::SetFdNoBlock(new_fd) == 0);
+        Assert(bbt::core::net::Util::SetFdNoBlock(new_fd) == 0);
         print("[server] read msg! fd=" << new_fd);
         int read_len = ::read(new_fd, buf, 1024);
         Assert(read_len != 0);

--- a/example/cocond.cc
+++ b/example/cocond.cc
@@ -1,6 +1,5 @@
 #include <bbt/coroutine/coroutine.hpp>
 
-std::mutex mutex;
 
 int main()
 {
@@ -16,7 +15,7 @@ int main()
         bbtco_desc("wait co") [](){
 
             /* 创建cond */
-            auto cond = bbtco_make_cocond(mutex);
+            auto cond = bbtco_make_cocond();
 
             /* 启动cond notify 协程 */
             bbtco_desc("notify co") [&](){

--- a/unit_test/Test_co_rwmutex.cc
+++ b/unit_test/Test_co_rwmutex.cc
@@ -4,7 +4,6 @@
 
 #include <bbt/coroutine/coroutine.hpp>
 
-std::mutex lock;
 
 BOOST_AUTO_TEST_SUITE(CoRWMutexTest)
 
@@ -20,7 +19,7 @@ BOOST_AUTO_TEST_CASE(t_rlock_block)
     bool succ = false;
 
     bbtco [&](){
-        auto cocond = bbt::coroutine::sync::CoCond::Create(lock);
+        auto cocond = bbt::coroutine::sync::CoCond::Create();
         auto rwlock = bbt::coroutine::sync::CoRWMutex::Create();
         bbtco [=, &succ](){
             rwlock->RLock();

--- a/unit_test/Test_cond.cc
+++ b/unit_test/Test_cond.cc
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(t_cond_wait)
     bbt::core::thread::CountDownLatch l2{nmax_co};
 
     bbtco [&](){
-        auto cond = sync::CoCond::Create(lock);
+        auto cond = sync::CoCond::Create();
 
         for (int i = 0; i < nmax_co; ++i) {
             bbtco [&](){


### PR DESCRIPTION
1、优化了Coroutine事件

原本的事件流程：

加锁 --> 初始化事件  --> 挂起 --> 注册事件 --> 解锁

这样做的原因是为了防止注册事件后触发。但是调度保证了Coroutine只能同时在一个Processer中被访问，所以加锁是无意义的，于是直接消除了这个锁。新的流程如下：

初始化事件 --> 挂起 --> 注册事件

两种都可以确保Coroutine在被挂起后才会被重新加入到就绪队列是线程安全的。

2、优化了CoCond
从使用锁修改为使用lockfree queue。其实最初是为了保证notify、wait是需要保护的，因为当时觉得我不加锁就无法保证notify_all操作是可靠的，但是发现我就算是使用无锁队列，在notify_all的时候多唤醒或者少唤醒了，其实并不影响，因为通常使用场景中，使用者是无法确定wait一定被某次notify唤醒。

3、调整了配置
现在全局的就绪队列使用了lockfree queue后，其实部分配置的变动不是很影响性能。因为每次pop、push操作基本上具有类似的性能消耗，以前从全局就绪队列获取item的操作会视为巨大的影响，原因就是加锁后，获取的量如果很少，那么加锁就很频繁，导致性能消耗很大。现在单次从lockfree queue的数据结构取多少对性能消耗影响较小。