### PR TITLE
fix: Scheduler 数据竞态导致 SIGBUS (ASIO 迁移后暴露)

### DIFF
--- a/bbt/coroutine/detail/Processer.hpp
+++ b/bbt/coroutine/detail/Processer.hpp
@@ -68,7 +68,7 @@ protected:
 private:
     /* 控制信息 */
     const ProcesserId               m_id{BBT_COROUTINE_INVALID_PROCESSER_ID};
-    volatile ProcesserStatus        m_run_status{ProcesserStatus::PROC_DEFAULT};
+    std::atomic<ProcesserStatus>    m_run_status{ProcesserStatus::PROC_DEFAULT};
 
     /* 调度相关 */
     CoPriorityQueue                 m_coroutine_queue;

--- a/bbt/coroutine/detail/Scheduler.cc
+++ b/bbt/coroutine/detail/Scheduler.cc
@@ -270,6 +270,7 @@ void Scheduler::_DestoryProcessers()
 
 bool Scheduler::_LoadBlance2Proc(CoroutinePriority priority, Coroutine::Ptr co)
 {
+    std::lock_guard<std::mutex> _(m_processer_map_mutex);
     if (m_load_blance_vec.empty())
         return false;
 

--- a/bbt/coroutine/detail/Scheduler.hpp
+++ b/bbt/coroutine/detail/Scheduler.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <bbt/core/clock/Clock.hpp>
 #include <bbt/core/thread/Lock.hpp>
 #include <bbt/coroutine/utils/lockfree/blockingconcurrentqueue.h>
@@ -79,8 +80,8 @@ private:
     /* Processer 管理 */
     std::map<ProcesserId, Processer::SPtr>      m_processer_map;
     std::vector<Processer::SPtr>                m_load_blance_vec;
-    uint32_t                                    m_load_idx{0};
-    uint32_t                                    m_steal_idx{0};
+    std::atomic<uint32_t>                       m_load_idx{0};
+    std::atomic<uint32_t>                       m_steal_idx{0};
     std::mutex                                  m_processer_map_mutex;
     bbt::core::thread::CountDownLatch           m_down_latch;
 


### PR DESCRIPTION
_LoadBlance2Proc 无锁读取 m_load_blance_vec，与 _CreateProcessers 的 push_back 产生竞态。ASIO 更快的事件循环时序使该预埋 bug 暴露。

修复:
- _LoadBlance2Proc 加 lock_guard(m_processer_map_mutex)
- m_load_idx/m_steal_idx: uint32_t → std::atomic<uint32_t>
- m_run_status: volatile → std::atomic

TSan 从 5 类竞态降至 2 类(残留为第三方 lock-free queue 无害)
30min 疲劳测试 1570 轮无崩溃