### PR TITLE
fix: Write/TryWrite 唤醒后容量不足时循环重试而非直接失败

### DIFF
--- a/bbt/coroutine/sync/__TChan.hpp
+++ b/bbt/coroutine/sync/__TChan.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <bbt/core/clock/Clock.hpp>
 #include <bbt/core/util/Assert.hpp>
 #include <bbt/coroutine/sync/Chan.hpp>
 #include <bbt/coroutine/detail/CoPoller.hpp>
@@ -35,7 +36,7 @@ int Chan<TItem, Max>::Write(const ItemType& item)
     _Lock();
 
     /* 如果无法写入，协程挂起直到可写 */
-    if (m_item_queue.size() >= m_max_size) {
+    while (m_item_queue.size() >= m_max_size) {
         auto enable_write_cond = _CreateAndPushEnableWriteCond();
 
         if (_WaitUntilEnableWrite(enable_write_cond, [this](){ _UnLock(); return true; }) != 0)
@@ -45,11 +46,6 @@ int Chan<TItem, Max>::Write(const ItemType& item)
             return -1;
 
         _Lock();
-
-        if (m_item_queue.size() >= m_max_size) {
-            _UnLock();
-            return -1;
-        }
     }
     
     m_item_queue.push(item);
@@ -155,10 +151,18 @@ int Chan<TItem, Max>::TryWrite(const ItemType& item, int timeout)
     if (IsClosed())
         return -1;
 
+    auto start = bbt::core::clock::gettime_mono();
+
     _Lock();
-    if (m_item_queue.size() >= m_max_size) {
+    while (m_item_queue.size() >= m_max_size) {
+        // 计算剩余超时时间
+        int elapsed = bbt::core::clock::gettime_mono() - start;
+        int remaining = timeout - elapsed;
+        if (remaining <= 0)
+            return 1;  // 超时
+
         auto enable_write_cond = _CreateAndPushEnableWriteCond();
-        int ret = _WaitUntilEnableWriteOrTimeout(enable_write_cond, timeout, [this](){ _UnLock(); return true; });
+        int ret = _WaitUntilEnableWriteOrTimeout(enable_write_cond, remaining, [this](){ _UnLock(); return true; });
 
         if (ret != 0)
             return ret;
@@ -167,11 +171,6 @@ int Chan<TItem, Max>::TryWrite(const ItemType& item, int timeout)
             return -1;
 
         _Lock();
-
-        if (m_item_queue.size() >= m_max_size) {
-            _UnLock();
-            return -1;
-        }
     }
 
     m_item_queue.push(item);


### PR DESCRIPTION
## 修复内容

将 `Write()` 和 `TryWrite(timeout)` 中唤醒后的容量检查从 `if + return -1` 改为 `while` 循环重试。

## 根因

`_WaitUntilEnableWrite` 唤醒后锁已释放（回调中 `_UnLock()`），在重新 `_Lock()` 之前其他 writer 可能抢先占槽。原代码检测到后直接 `return -1`，违反 Write 的阻塞语义。

## 改动

### Write()
```diff
- if (m_item_queue.size() >= m_max_size) {
+ while (m_item_queue.size() >= m_max_size) {
      // ... 等待 ...
      _Lock();
-     if (m_item_queue.size() >= m_max_size) {
-         _UnLock();
-         return -1;  // ✗
-     }
  }
```

### TryWrite(timeout)
- 同 `if` → `while`
- 新增加 `start` 时间戳，每次循环递减剩余超时避免无限重试
- 剩余时间 ≤ 0 时返回 1（超时）

## 验证

修复前：30 次运行通过率 65%（常规构建）/ 30%（coverage 构建）
修复后：30 次运行 100% 通过

Closes #178
