### PR TITLE
fix(coroutine): PollOnce false negative causes progressive timer freeze

### DIFF
--- a/bbt/coroutine/detail/CoPoller.cc
+++ b/bbt/coroutine/detail/CoPoller.cc
@@ -40,10 +40,7 @@ std::shared_ptr<bbt::pollevent::Event> CoPoller::CreateEvent(int fd, short event
 bool CoPoller::PollOnce()
 {
     errno = 0;
-    int before_num = m_event_loop->GetEventNum();
-    bool ret = (m_event_loop->StartLoop(bbt::pollevent::EventLoopOpt::LOOP_NONBLOCK) == 0);
-
-    return (ret && m_event_loop->GetEventNum() != before_num);
+    return (m_event_loop->StartLoop(bbt::pollevent::EventLoopOpt::LOOP_NONBLOCK) == 0);
 }
 
 int CoPoller::NotifyCustomEvent(std::shared_ptr<CoPollEvent> event)

--- a/bbt/coroutine/detail/Profiler.cc
+++ b/bbt/coroutine/detail/Profiler.cc
@@ -117,4 +117,28 @@ void Profiler::ProfileInfo(std::string& info)
     }
 }
 
+void Profiler::DumpStderr()
+{
+    auto elapsed_ms = (bbt::core::clock::now<>() - m_scheduler_begin_timestamp).count();
+    fprintf(stderr,
+        "[PROFILE] t=%llums event_reg=%llu event_trig=%llu steal=%llu co_done=%llu\n",
+        (unsigned long long)elapsed_ms,
+        (unsigned long long)m_regist_event_count.load(),
+        (unsigned long long)m_trigger_event_count.load(),
+        (unsigned long long)m_total_steal_count.load(),
+        (unsigned long long)m_total_done_co_count.load());
+
+    std::unique_lock<std::mutex> _(m_processer_map_mutex);
+    for (auto&& proc : m_processer_map) {
+        fprintf(stderr,
+            "  PID=%llu q=%zu swap=%llu steal=%llu/%llu suspend_ms=%llu\n",
+            (unsigned long long)proc.second->GetId(),
+            proc.second->GetExecutableNum(),
+            (unsigned long long)proc.second->GetContextSwapTimes(),
+            (unsigned long long)proc.second->GetStealSuccTimes(),
+            (unsigned long long)proc.second->GetStealCount(),
+            (unsigned long long)(proc.second->GetSuspendCostTime() / 1000));
+    }
+}
+
 } // namespace bbt::coroutine::detail

--- a/bbt/coroutine/detail/Profiler.hpp
+++ b/bbt/coroutine/detail/Profiler.hpp
@@ -42,6 +42,9 @@ public:
 
     void                        ProfileInfo(std::string& info);
 
+    // 紧凑格式输出到 stderr，用于压测时每秒采样
+    void                        DumpStderr();
+
     struct ProcesserProfile
     {
         ProcesserId id;


### PR DESCRIPTION
## Summary

修复 `CoPoller::PollOnce()` 中的 false negative bug —— Timer 回调不创建 Event 对象，导致 `GetEventNum()` 判断误判为"无事发生"，事件积压后全部协程渐进冻结。

## Root Cause

`PollOnce()` 原逻辑：

```cpp
int before_num = m_event_loop->GetEventNum();
bool ret = (m_event_loop->StartLoop(...) == 0);
return (ret && m_event_loop->GetEventNum() != before_num);
```

`StartLoop` 成功 dispatch 了 timer 事件，但 timer 回调不创建/销毁 Event 对象 → `GetEventNum()` 前后相同 → `PollOnce()` 返回 false → `_OnUpdate()` 提前退出 → timer 事件持续积压 → 所有协程饿死。

## Fix

```cpp
return (m_event_loop->StartLoop(bbt::pollevent::EventLoopOpt::LOOP_NONBLOCK) == 0);
```

直接返回 `StartLoop` 的结果，不再依赖 `GetEventNum()`。

## Verification

| 测试 | 结果 |
|------|------|
| 30min 疲劳测试 | ✅ 6/6 模块零冻结 |
| 1h 疲劳测试 | ✅ 6/6 模块零冻结 (61 samples each, 3600s) |

修复前 1h 测试在 ~27min 全部冻结。修复后两次测试均完全通过。

## Changes

- `CoPoller.cc`: 核心修复 (-4 / +1)
- `Profiler.cc/hpp`: 新增 `DumpStderr()` 诊断方法
- `CMakeLists.txt`: benchmark_test 编译配置
