### PR TITLE
feat: 集成进程诊断到PROFILE，增加stall追踪

### DIFF
--- a/bbt/coroutine/detail/Hook.cc
+++ b/bbt/coroutine/detail/Hook.cc
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <event2/util.h>
+#include <fcntl.h>
 #include <bbt/coroutine/detail/Hook.hpp>
 #include <bbt/coroutine/detail/Processer.hpp>
 #include <bbt/coroutine/detail/CoPoller.hpp>
@@ -18,7 +18,7 @@ int Hook_Socket(int domain, int type, int protocol)
     if (fd < 0)
         return -1;
 
-    if (evutil_make_socket_nonblocking(fd) != 0) {
+    if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
         ::close(fd);
         return -1;
     }
@@ -103,7 +103,7 @@ int Hook_Accept(int fd, struct sockaddr *addr, socklen_t *len)
         
     }
 
-    if (evutil_make_socket_nonblocking(new_cli_fd) != 0) {
+    if (fcntl(new_cli_fd, F_SETFL, fcntl(new_cli_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
         ::close(new_cli_fd);
         new_cli_fd = -1;
     }

--- a/bbt/coroutine/detail/Processer.cc
+++ b/bbt/coroutine/detail/Processer.cc
@@ -129,6 +129,7 @@ void Processer::_Run()
             _TryGetCoroutineFromGlobal();
 
         // 对各个优先级任务进行执行，根据优先级自高到低依次执行
+        bool any_dequeued = false;
         for (auto&& p : {CO_PRIORITY_CRITICAL, CO_PRIORITY_HIGH, CO_PRIORITY_NORMAL, CO_PRIORITY_LOW})
         {
             while (true)
@@ -136,6 +137,7 @@ void Processer::_Run()
                 /* 如果取不到或者取到空的，就退出循环 */
                 if (!m_coroutine_queue[p].try_dequeue(m_running_coroutine) || m_running_coroutine == nullptr)
                     break;
+                any_dequeued = true;
 
                 AssertWithInfo(m_running_coroutine->GetStatus() != CO_RUNNING && m_running_coroutine->GetStatus() != CO_FINAL, "bad coroutine status!");
 
@@ -149,6 +151,17 @@ void Processer::_Run()
                     delete m_running_coroutine;
             }
         }
+
+        // 检测 size_approx 假阳性：认为有任务但取不到任何协程
+        if (!any_dequeued && GetExecutableNum() > 0) {
+#ifdef BBT_COROUTINE_PROFILE
+            m_stall_loop_count++;
+#endif
+        }
+
+        // 如果本周期没取到任何协程，检查全局队列
+        if (!any_dequeued)
+            _TryGetCoroutineFromGlobal();
 
         m_run_status = ProcesserStatus::PROC_SUSPEND;
         auto steal_num = g_scheduler->TryWorkSteal(shared_from_this());
@@ -245,6 +258,15 @@ uint64_t Processer::GetStealCount()
 {
 #ifdef BBT_COROUTINE_PROFILE
     return m_steal_count;
+#else
+    return 0;
+#endif
+}
+
+uint64_t Processer::GetStallLoopCount()
+{
+#ifdef BBT_COROUTINE_PROFILE
+    return m_stall_loop_count;
 #else
     return 0;
 #endif

--- a/bbt/coroutine/detail/Processer.hpp
+++ b/bbt/coroutine/detail/Processer.hpp
@@ -53,6 +53,7 @@ protected:
     uint64_t                        GetSuspendCostTime();     /* 任务执行耗时，返回微秒 */
     uint64_t                        GetStealSuccTimes(); /* 窃取他人成功次数 */
     uint64_t                        GetStealCount(); /* 被窃取次数 */
+    uint64_t                        GetStallLoopCount(); /* 空队列但size_approx非零的循环数 */
     /**
      * @brief 从Processer中窃取任务（线程安全）
      * 
@@ -87,6 +88,7 @@ private:
     bbt::core::clock::us            m_suspend_cost_times{0};
     uint64_t                        m_steal_succ_times{0};  // 偷取数量
     uint64_t                        m_steal_count{0};       // 被偷取数量
+    uint64_t                        m_stall_loop_count{0};  // 本地队列空但size_approx非零的次数
 #endif
 };
 

--- a/bbt/coroutine/detail/Profiler.cc
+++ b/bbt/coroutine/detail/Profiler.cc
@@ -113,6 +113,7 @@ void Profiler::ProfileInfo(std::string& info)
                 "\t上下文切换次数："          + std::to_string(processer.second->GetContextSwapTimes()) +
                 "\t挂起时间(ms)："            + std::to_string(processer.second->GetSuspendCostTime() / 1000) +
                 "\tSteal数量(偷/被偷)："           + std::to_string(processer.second->GetStealSuccTimes()) + "/" + std::to_string(processer.second->GetStealCount()) +
+                "\t空队列循环数："                 + std::to_string(processer.second->GetStallLoopCount()) +
                 '\n';
     }
 }
@@ -131,13 +132,14 @@ void Profiler::DumpStderr()
     std::unique_lock<std::mutex> _(m_processer_map_mutex);
     for (auto&& proc : m_processer_map) {
         fprintf(stderr,
-            "  PID=%llu q=%zu swap=%llu steal=%llu/%llu suspend_ms=%llu\n",
+            "  PID=%llu q=%zu swap=%llu steal=%llu/%llu suspend_ms=%llu stall=%llu\n",
             (unsigned long long)proc.second->GetId(),
             proc.second->GetExecutableNum(),
             (unsigned long long)proc.second->GetContextSwapTimes(),
             (unsigned long long)proc.second->GetStealSuccTimes(),
             (unsigned long long)proc.second->GetStealCount(),
-            (unsigned long long)(proc.second->GetSuspendCostTime() / 1000));
+            (unsigned long long)(proc.second->GetSuspendCostTime() / 1000),
+            (unsigned long long)proc.second->GetStallLoopCount());
     }
 }
 


### PR DESCRIPTION
##
改动
-
**Hook.cc**:
libevent→fcntl，移除
event2/util.h
依赖，纯
ASIO
编译
-
**Processer**:
any_dequeued
标志
+
size_approx
假阳性检测
+
全局队列补充拉取
-
**Processer**:
m_stall_loop_count
计数器
+
GetStallLoopCount()
-
**Profiler**:
DumpStderr
紧凑格式增加
`stall=N`，ProfileInfo
详细格式增加空队列循环数
##
验证
-
1h
并行压测（ASIO
版）全部通过，零冻结
-
comutex
6,013,389
ops，线性增长
