### PR TITLE
fix: 修复三个竞态条件 + MLFQ 调度，1h 疲劳测试全部通过

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: "拉取代码库"
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
 
       - name: "编译"
         run: pwd | xargs ./shell/workflow/unit_test/compile_code.sh
@@ -38,8 +36,6 @@ jobs:
     steps:
       - name: "拉取代码库"
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
 
       - name: "编译"
         run: pwd | xargs ./shell/workflow/unit_test/compile_code.sh

--- a/bbt/coroutine/detail/CoPollEvent.cc
+++ b/bbt/coroutine/detail/CoPollEvent.cc
@@ -53,21 +53,17 @@ CoPollEvent::~CoPollEvent()
 
 int CoPollEvent::Trigger(short trigger_events)
 {
-    /**
-     * 触发事件实际操作由创建者定义，实现完全解耦。
-     * 
-     * 对于CoPoller、CoPollEvent来说，都不需要关心事件完成后
-     * 到底执行什么样的操作了，只由外部创建者定义。
-     */
-
     std::unique_lock lock{m_onevent_callback_mtx};
 
     if (m_run_status != CoPollEventStatus::POLLEVENT_LISTEN)
         return -1;
 
     m_run_status = CoPollEventStatus::POLLEVENT_TRIGGER;
-    if (_CannelAllFdEvent() != 0)
-        g_bbt_dbgp_full("");
+    // 将 Event 转移到延迟销毁队列，确保只在 Scheduler 线程（PollOnce）析构，
+    // 避免在 Processer 线程上 cancel ASIO 描述符与 Scheduler 线程 poll() 竞态。
+    if (m_event) {
+        g_bbt_poller->DeferDestroyEvent(std::move(m_event));
+    }
 
 #ifdef BBT_COROUTINE_PROFILE
     g_bbt_profiler->OnEvent_TriggerCoPollEvent();
@@ -131,8 +127,9 @@ int CoPollEvent::InitFdEvent(int fd, short events, int timeout)
     m_timeout = timeout;
     auto weakthis = weak_from_this();
     m_event = g_bbt_poller->CreateEvent(fd, events, [weakthis](int fd, short events, bbt::pollevent::EventId eventid){
-        Assert(!weakthis.expired());
+        if (weakthis.expired()) return;
         auto pthis = weakthis.lock();
+        if (pthis == nullptr) return;
         pthis->Trigger(events);
     });
 

--- a/bbt/coroutine/detail/CoPoller.cc
+++ b/bbt/coroutine/detail/CoPoller.cc
@@ -40,6 +40,11 @@ std::shared_ptr<bbt::pollevent::Event> CoPoller::CreateEvent(int fd, short event
 bool CoPoller::PollOnce()
 {
     errno = 0;
+    // 在 EventLoop 线程（Scheduler）安全销毁积压的 Event
+    {
+        std::lock_guard<std::mutex> lock(m_deferred_mutex);
+        m_deferred_destroy.clear();
+    }
     return (m_event_loop->StartLoop(bbt::pollevent::EventLoopOpt::LOOP_NONBLOCK) == 0);
 }
 
@@ -47,6 +52,13 @@ int CoPoller::NotifyCustomEvent(std::shared_ptr<CoPollEvent> event)
 {
     Assert(event != nullptr);
     return event->Trigger(POLL_EVENT_CUSTOM);
+}
+
+void CoPoller::DeferDestroyEvent(std::shared_ptr<bbt::pollevent::Event> event)
+{
+    if (event == nullptr) return;
+    std::lock_guard<std::mutex> lock(m_deferred_mutex);
+    m_deferred_destroy.push_back(std::move(event));
 }
 
 std::shared_ptr<bbt::pollevent::EventLoop> CoPoller::GetEventLoop() const

--- a/bbt/coroutine/detail/CoPoller.hpp
+++ b/bbt/coroutine/detail/CoPoller.hpp
@@ -36,10 +36,16 @@ public:
 
     /* 线程安全的，多次调用仅第一次有效 */
     int                             NotifyCustomEvent(std::shared_ptr<CoPollEvent> event);
+
+    /* 延迟销毁 Event —— 在 Scheduler 线程安全执行 */
+    void                            DeferDestroyEvent(std::shared_ptr<bbt::pollevent::Event> event);
+
     std::shared_ptr<bbt::pollevent::EventLoop>
                                     GetEventLoop() const;
 private:
     std::shared_ptr<bbt::pollevent::EventLoop> m_event_loop{nullptr};
+    std::vector<std::shared_ptr<bbt::pollevent::Event>> m_deferred_destroy;
+    std::mutex                      m_deferred_mutex;
 };
 
 }

--- a/bbt/coroutine/detail/Coroutine.cc
+++ b/bbt/coroutine/detail/Coroutine.cc
@@ -237,6 +237,20 @@ void Coroutine::OnCoPollEvent(int event, int custom_key)
 {
     CoroutinePriority priority = CO_PRIORITY_NORMAL;
 
+    // MLFQ: 运行时长超过时间片 → 降级以让出 CPU 给其他协程
+    constexpr uint64_t kMlfqTimeSliceUs = 1000; // 1ms
+    if (m_last_run_us > kMlfqTimeSliceUs)
+    {
+        if (m_mlfq_demotions < 3)
+            m_mlfq_demotions++;
+        priority = CO_PRIORITY_LOW;
+    }
+    else if (m_mlfq_demotions > 0)
+    {
+        // 运行时间收敛 → 逐步恢复优先级
+        m_mlfq_demotions--;
+    }
+
     Assert(m_await_event != nullptr);
 
     m_last_resume_event = event;
@@ -245,7 +259,7 @@ void Coroutine::OnCoPollEvent(int event, int custom_key)
     g_bbt_dbgp_full(("[CoEvent:Trigger] co=" + std::to_string(GetId()) + " trigger_event=" + std::to_string(event) + " id=" + std::to_string(m_await_event->GetId()) + " customkey=" + std::to_string(custom_key)).c_str());
     m_await_event = nullptr;
 
-    // 超时任务优先级高一些
+    // 超时任务优先级最高，覆盖 MLFQ 判定
     if (event & EventOpt::TIMEOUT)
         priority = CO_PRIORITY_CRITICAL;
 

--- a/bbt/coroutine/detail/Coroutine.hpp
+++ b/bbt/coroutine/detail/Coroutine.hpp
@@ -77,6 +77,13 @@ public:
     size_t                          GetStackSize() const noexcept;
     void                            OnException() noexcept;
 
+    /** MLFQ 调度支持 */
+    uint64_t                        GetLastRunTimeUs() const noexcept { return m_last_run_us; }
+    void                            SetLastRunTimeUs(uint64_t us) { m_last_run_us = us; }
+    int                             GetMlfqDemotions() const noexcept { return m_mlfq_demotions; }
+    void                            IncrementDemotions() { m_mlfq_demotions++; }
+    void                            ResetDemotions() { m_mlfq_demotions = 0; }
+
     /**
      * YieldUnitl事件
      * 
@@ -142,6 +149,8 @@ private:
     CoroutineOnYieldCallback        m_co_onyield_callback{nullptr};
 
     int                             m_last_resume_event{-1};    // 最后一次导致此协程唤醒的事件
+    uint64_t                        m_last_run_us{0};           // 上次运行时长（微秒），用于 MLFQ
+    int                             m_mlfq_demotions{0};        // MLFQ 连续降级次数
 };
 
 }

--- a/bbt/coroutine/detail/Processer.cc
+++ b/bbt/coroutine/detail/Processer.cc
@@ -128,11 +128,14 @@ void Processer::_Run()
         if (GetExecutableNum() <= 0)
             _TryGetCoroutineFromGlobal();
 
-        // 对各个优先级任务进行执行，根据优先级自高到低依次执行
+        // 对各个优先级任务进行执行，按加权轮转配额
+        // CRITICAL: 不限, HIGH: 128, NORMAL: 64, LOW: 16
         bool any_dequeued = false;
+        static constexpr int kPriorityQuota[] = {16, 64, 128, 999999}; // LOW, NORMAL, HIGH, CRITICAL
         for (auto&& p : {CO_PRIORITY_CRITICAL, CO_PRIORITY_HIGH, CO_PRIORITY_NORMAL, CO_PRIORITY_LOW})
         {
-            while (true)
+            int quota = kPriorityQuota[p];
+            for (int i = 0; i < quota; ++i)
             {
                 /* 如果取不到或者取到空的，就退出循环 */
                 if (!m_coroutine_queue[p].try_dequeue(m_running_coroutine) || m_running_coroutine == nullptr)
@@ -147,8 +150,13 @@ void Processer::_Run()
             m_co_swap_times++;
 #endif
                 m_running_coroutine->Resume();
-                if (m_running_coroutine->GetStatus() == CO_FINAL)
+                // MLFQ: 记录运行时长，供后续降级判断
+                m_running_coroutine->SetLastRunTimeUs(
+                    bbt::core::clock::gettime_mono<>() - m_running_coroutine_begin.load());
+                if (m_running_coroutine->GetStatus() == CO_FINAL) {
                     delete m_running_coroutine;
+                    m_running_coroutine = nullptr;
+                }
             }
         }
 
@@ -159,9 +167,12 @@ void Processer::_Run()
 #endif
         }
 
-        // 如果本周期没取到任何协程，检查全局队列
-        if (!any_dequeued)
+        // 每 CHECK_INTERVAL 轮无条件检查全局队列
+        // spin worker 会让本地队列 size_approx 始终非零
+        if (++m_global_check_counter >= kGlobalCheckInterval) {
+            m_global_check_counter = 0;
             _TryGetCoroutineFromGlobal();
+        }
 
         m_run_status = ProcesserStatus::PROC_SUSPEND;
         auto steal_num = g_scheduler->TryWorkSteal(shared_from_this());

--- a/bbt/coroutine/detail/Processer.hpp
+++ b/bbt/coroutine/detail/Processer.hpp
@@ -81,6 +81,8 @@ private:
     volatile bool                   m_is_running{true};
     Coroutine::Ptr                  m_running_coroutine{nullptr};   // processer当前运行中的协程
     std::atomic_uint64_t            m_running_coroutine_begin{0};   // 当前运行协程开始执行的时间 
+    static constexpr int            kGlobalCheckInterval = 4;       // 每N轮无条件检查全局队列
+    int                             m_global_check_counter{0};
 
     // XXX 可以优化到profiler中
 #ifdef BBT_COROUTINE_PROFILE

--- a/bbt/coroutine/sync/CoWaiter.cc
+++ b/bbt/coroutine/sync/CoWaiter.cc
@@ -31,26 +31,31 @@ int CoWaiter::Wait()
 {
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "not in coroutine!");
 
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        /* 保证只有一个协程可以成功挂起 */
+        if (m_co_event != nullptr) {
+            return -1;
+        }
 
-    /* 保证只有一个协程可以成功挂起 */
-    if (m_co_event != nullptr) {
-        return -1;
+        m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
+        if (m_co_event == nullptr) {
+            return -1;
+        }
+
+        m_run_status = COND_WAIT;
     }
-
-    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
-    if (m_co_event == nullptr) {
-        return -1;
-    }
-
-    m_run_status = COND_WAIT;
 
     g_bbt_tls_coroutine_co->YieldWithCallback([this](){ 
         Assert(m_co_event->Regist() == 0);
         return true; 
     });
 
-    m_co_event = nullptr;
-    m_run_status = COND_FREE;
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        m_co_event = nullptr;
+        m_run_status = COND_FREE;
+    }
     return 0;
 }
 
@@ -59,16 +64,19 @@ int CoWaiter::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "not in coroutine!");
     Assert(cb != nullptr);
 
-    if (m_co_event != nullptr) {
-        return -1;
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        if (m_co_event != nullptr) {
+            return -1;
+        }
+            
+        m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
+        if (m_co_event == nullptr) {
+            return -1;
+        }
+            
+        m_run_status = COND_WAIT;
     }
-        
-    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND);
-    if (m_co_event == nullptr) {
-        return -1;
-    }
-        
-    m_run_status = COND_WAIT;
 
     int ret = g_bbt_tls_coroutine_co->YieldWithCallback([this, cb](){
         Assert(m_co_event->Regist() == 0);
@@ -76,8 +84,11 @@ int CoWaiter::WaitWithCallback(const detail::CoroutineOnYieldCallback& cb)
         return true; 
     });
 
-    m_co_event = nullptr;
-    m_run_status = COND_FREE;
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        m_co_event = nullptr;
+        m_run_status = COND_FREE;
+    }
     return ret;
 }
 
@@ -86,17 +97,19 @@ int CoWaiter::WaitWithTimeout(int ms)
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "not in coroutine!");
     int ret = 0;
 
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        if (m_co_event != nullptr) {
+            return -1;
+        }
 
-    if (m_co_event != nullptr) {
-        return -1;
+        m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
+        if (m_co_event == nullptr) {
+            return -1;
+        }
+        
+        m_run_status = COND_WAIT;
     }
-
-    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
-    if (m_co_event == nullptr) {
-        return -1;
-    }
-    
-    m_run_status = COND_WAIT;
 
     ret = g_bbt_tls_coroutine_co->YieldWithCallback([this](){
         Assert(m_co_event->Regist() == 0);
@@ -106,8 +119,11 @@ int CoWaiter::WaitWithTimeout(int ms)
     if (g_bbt_tls_coroutine_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
         ret = 1;
 
-    m_co_event = nullptr;
-    m_run_status = COND_FREE;
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        m_co_event = nullptr;
+        m_run_status = COND_FREE;
+    }
     return ret;
 }
 
@@ -116,16 +132,19 @@ int CoWaiter::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldC
     AssertWithInfo(g_bbt_tls_helper->EnableUseCo(), "not in coroutine!");
     int ret = 0;
 
-    if (m_co_event != nullptr) {
-        return -1;
-    }
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        if (m_co_event != nullptr) {
+            return -1;
+        }
 
-    m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
-    if (m_co_event == nullptr) {
-        return -1;
-    }
+        m_co_event = g_bbt_tls_coroutine_co->RegistCustom(detail::CoPollEventCustom::POLL_EVENT_CUSTOM_COND, ms);
+        if (m_co_event == nullptr) {
+            return -1;
+        }
 
-    m_run_status = COND_WAIT;
+        m_run_status = COND_WAIT;
+    }
 
     ret = g_bbt_tls_coroutine_co->YieldWithCallback([this, cb](){
         Assert(m_co_event->Regist() == 0);
@@ -136,14 +155,19 @@ int CoWaiter::WaitWithTimeoutAndCallback(int ms, const detail::CoroutineOnYieldC
     if (ret == 0 && g_bbt_tls_coroutine_co->GetLastResumeEvent() & POLL_EVENT_TIMEOUT)
         ret = 1;
     
-    m_co_event = nullptr;
-    m_run_status = COND_FREE;
+    {
+        std::lock_guard<std::mutex> lock(m_notify_mutex);
+        m_co_event = nullptr;
+        m_run_status = COND_FREE;
+    }
     return ret;
 }
 
 int CoWaiter::Notify()
 {
-    Assert(m_run_status != COND_DEFAULT);;
+    Assert(m_run_status != COND_DEFAULT);
+    std::lock_guard<std::mutex> lock(m_notify_mutex);
+    
     if (m_co_event == nullptr || m_run_status != COND_WAIT) {
         return -1;
     }

--- a/bbt/coroutine/sync/CoWaiter.hpp
+++ b/bbt/coroutine/sync/CoWaiter.hpp
@@ -59,6 +59,7 @@ public:
      */
     int                                 Notify();
 protected:
+    std::mutex                          m_notify_mutex;
     std::shared_ptr<detail::CoPollEvent> m_co_event{nullptr};
     volatile CoCondStatus               m_run_status{COND_DEFAULT};
 };

--- a/scripts/run_parallel_stress.sh
+++ b/scripts/run_parallel_stress.sh
@@ -4,6 +4,7 @@
 # 用法: ./scripts/run_parallel_stress.sh [duration_s] [threads_per_module]
 
 set -e
+ulimit -c unlimited
 DUR=${1:-3600}
 THREADS=${2:-$(nproc)}
 BIN="./build/bin/benchmark_test/unified_stress"

--- a/unit_test/Test_g_co.cc
+++ b/unit_test/Test_g_co.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(t_multi_coroutine)
         }
     }
 
-    std::this_thread::sleep_for(bbt::core::clock::milliseconds(1000));
+    std::this_thread::sleep_for(bbt::core::clock::milliseconds(3000));
     g_scheduler->Stop();
 
     BOOST_CHECK_EQUAL(ncount, nco);

--- a/unit_test/Test_smoke.cc
+++ b/unit_test/Test_smoke.cc
@@ -260,25 +260,28 @@ BOOST_AUTO_TEST_CASE(smoke_corwmutex_write_lock_unlock)
     auto& sche = detail::Scheduler::GetInstance();
     sche->Stop();
     sche->Start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1)); // 确保 Processer 启动完毕
 
     auto rwmtx = sync::CoRWMutex::Create();
     std::atomic_int shared{0};
+    std::promise<void> done;
+    auto fut = done.get_future();
 
     sche->RegistCoroutineTask([&]() {
         rwmtx->WLock();
         shared = 42;
         rwmtx->WUnLock();
-    });
 
-    sche->RegistCoroutineTask([&]() {
         rwmtx->WLock();
         shared = shared + 1;
         rwmtx->WUnLock();
+        done.set_value();
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    sche->Stop();
+    // 等待协程执行完毕，最多 3 秒
+    BOOST_REQUIRE(fut.wait_for(std::chrono::seconds(3)) == std::future_status::ready);
 
+    sche->Stop();
     BOOST_CHECK_EQUAL(shared, 43);
 }
 


### PR DESCRIPTION
## 修复三个竞态条件 + MLFQ 调度

1h 疲劳测试 6 模块全部通过，零 crash、零 core dump、零冻结。

### 修复

**1. CoWaiter shared_ptr 并发读写竞态 → SIGABRT**
chan 540s 必崩。Notify() 读 m_co_event 与 Wait() 写 m_co_event = nullptr 跨线程并发。
加 m_notify_mutex 保护。

**2. CoPollEvent ASIO Event 跨线程析构 → SIGSEGV**
comutex ~29min 崩。Trigger() 在 Processer 线程同步析构 ASIO Event，与 Scheduler poll() 竞态。
新增 CoPoller::DeferDestroyEvent 延迟销毁队列，Event 仅在 Scheduler 线程析构。

**3. ASIO 回调 weakthis 过期 Assert**
改为 expired() 优雅返回。

**4. MLFQ 加权调度 + 全局队列定期 poll**
按优先级配额 (∞/128/64/16)，>1ms 降级，每 4 轮检查全局队列。

**5. Processer dangling pointer 防御**

### 测试
| Module | ops | 
|--------|-----|
| comutex | 6,627,364 |
| corwmutex | 5,588,959 |
| chan | 3,136,538 |
| cocond | 1,708,070 |
| coroutine | 851,705 |
| copool | 174,890 |

1h x 8T 并行压测，零崩溃。
