### PR TITLE
fix: Scheduler 优雅关闭 — Stop() 不再挂起

### DIFF
--- a/bbt/coroutine/detail/Processer.cc
+++ b/bbt/coroutine/detail/Processer.cc
@@ -142,6 +142,13 @@ void Processer::_Run()
                     break;
                 any_dequeued = true;
 
+                /* 强制关闭模式：跳过协程执行，直接回收 */
+                if (m_is_shutdown) {
+                    delete m_running_coroutine;
+                    m_running_coroutine = nullptr;
+                    continue;
+                }
+
                 AssertWithInfo(m_running_coroutine->GetStatus() != CO_RUNNING && m_running_coroutine->GetStatus() != CO_FINAL, "bad coroutine status!");
 
                 // 执行前设置当前协程缓存
@@ -201,12 +208,24 @@ void Processer::Stop()
 {
     Coroutine::Ptr item = nullptr;
 
-    do {
-        m_is_running = false;
-        std::this_thread::sleep_for(bbt::core::clock::milliseconds(50));
-        m_run_cond.notify_one();
-    } while (m_run_status != ProcesserStatus::PROC_EXIT);
+    m_is_running = false;
 
+    /* 等待 _Run 循环退出（最多 5 秒） */
+    constexpr int kMaxRetries = 100;
+    for (int retry = 0; retry < kMaxRetries; ++retry) {
+        if (m_run_status == ProcesserStatus::PROC_EXIT)
+            break;
+        m_run_cond.notify_one();
+        std::this_thread::sleep_for(bbt::core::clock::milliseconds(50));
+    }
+
+    /* 超时强杀：直接回收协程 */
+    if (m_run_status != ProcesserStatus::PROC_EXIT) {
+        // 设置 shutdown 标志，_Run 循环检测到此标志时跳过协程执行
+        m_is_shutdown = true;
+        m_run_cond.notify_one();
+        std::this_thread::sleep_for(bbt::core::clock::milliseconds(100));
+    }
 
     /* 释放所有协程 */
     for (auto && it : m_coroutine_queue)

--- a/bbt/coroutine/detail/Processer.hpp
+++ b/bbt/coroutine/detail/Processer.hpp
@@ -79,6 +79,7 @@ private:
 
     /* 运行时相关 */
     volatile bool                   m_is_running{true};
+    volatile bool                   m_is_shutdown{false};  // 强制关闭标志，跳过协程执行
     Coroutine::Ptr                  m_running_coroutine{nullptr};   // processer当前运行中的协程
     std::atomic_uint64_t            m_running_coroutine_begin{0};   // 当前运行协程开始执行的时间 
     static constexpr int            kGlobalCheckInterval = 4;       // 每N轮无条件检查全局队列

--- a/bbt/coroutine/detail/Scheduler.cc
+++ b/bbt/coroutine/detail/Scheduler.cc
@@ -31,6 +31,8 @@ Scheduler::Scheduler():
 
 Scheduler::~Scheduler()
 {
+    if (m_is_running || m_sche_thread != nullptr)
+        Stop();
 }
 
 void Scheduler::_Init()

--- a/benchmark_test/fatigue_metrics.h
+++ b/benchmark_test/fatigue_metrics.h
@@ -200,7 +200,14 @@ struct Metrics {
 
     void reporter_loop(int interval_s) {
         while (reporter_running.load(std::memory_order_relaxed)) {
-            std::this_thread::sleep_for(std::chrono::seconds(interval_s));
+            // 用小步长睡眠，快速响应 stop 信号
+            auto step = std::chrono::milliseconds(100);
+            auto total = std::chrono::seconds(interval_s);
+            auto elapsed = std::chrono::milliseconds(0);
+            while (elapsed < total && reporter_running.load(std::memory_order_relaxed)) {
+                std::this_thread::sleep_for(step);
+                elapsed += step;
+            }
             if (reporter_running.load(std::memory_order_relaxed)) {
                 dump_json();
             }

--- a/benchmark_test/unified_stress.cc
+++ b/benchmark_test/unified_stress.cc
@@ -137,12 +137,12 @@ int main(int argc,char**argv){
 
     printf("[unified_stress] started\n");
     for(int i=0;i<dur&&g_running;++i){
-        sleep(1);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
 #ifdef BBT_COROUTINE_PROFILE
         if (i % 10 == 0) g_bbt_profiler->DumpStderr();
 #endif
     }
-    g_running=0;sleep(1);
+    g_running=0;std::this_thread::sleep_for(std::chrono::seconds(1));
     stop_all();g_scheduler->Stop();
     printf("[unified_stress] done\n");
     return 0;


### PR DESCRIPTION
## 问题

`unified_stress` 短测试（dur<60s）后 Stop() 永久挂起，`[unified_stress] done` 从不输出。

## 根因（两个）

### 1. 主线程 sleep(1) 被协程 hook 拦截

```cpp
// unified_stress.cc:139
for(int i=0;i<dur&&g_running;++i){
    sleep(1);  // ← Hook_Sleep 断言"must be in coroutine context"
}
```

**修复**: 改为 `std::this_thread::sleep_for(std::chrono::seconds(1))`

### 2. reporter 线程大粒度 sleep

```cpp
// fatigue_metrics.h:202
while (reporter_running) {
    std::this_thread::sleep_for(std::chrono::seconds(interval_s));  // 默认60s
}
```

`stop_reporter()` 设置 `reporter_running=false` 后 `join()` 需等 sleep 自然到期（最多60s/模块 × 6模块 = 360s）。

**修复**: 改为 100ms 小步长轮询，stop 响应从 60s → <100ms。

## Processer 防御

- `Stop()` 加 5s 超时（100次×50ms），超时后设置 `m_is_shutdown` 强制跳过协程执行
- `_Run()` 循环检测 `m_is_shutdown` 时直接 delete 协程，不执行

## Scheduler 防御

- `~Scheduler()` 自动调用 `Stop()`，防止遗漏

## 验证

```
comutex:   OK 7s ✅
copool:    OK 7s ✅  
coroutine: OK 6s ✅
ctest:     14/14 ✅
```

Closes #173