### PR TITLE
feat: CoLockGuard + CoUniqueLock RAII 守卫 for CoMutex

### DIFF
--- a/bbt/coroutine/sync/CoLockGuard.hpp
+++ b/bbt/coroutine/sync/CoLockGuard.hpp
@@ -1,0 +1,161 @@
+#pragma once
+#include <bbt/core/util/Assert.hpp>
+#include <utility>
+
+namespace bbt::coroutine::sync
+{
+
+/**
+ * @brief RAII 协程锁守卫，构造时 Lock，析构时 UnLock
+ * 
+ * 类似 std::lock_guard，但适用于协程同步原语（CoMutex 等）。
+ * 不可拷贝、不可移动。
+ * 
+ * 析构函数 noexcept — 异常路径下也不会抛异常。
+ * 死锁检测由底层 Mutex::Lock() 内部的 assert 实现。
+ * 
+ * @tparam Mutex 满足 Lockable 概念：Lock() / UnLock()
+ */
+template<typename Mutex>
+class CoLockGuard
+{
+public:
+    explicit CoLockGuard(Mutex& m) noexcept(false)
+        : m_mutex(m)
+    {
+        m_mutex.Lock();
+    }
+
+    ~CoLockGuard() noexcept
+    {
+        m_mutex.UnLock();
+    }
+
+    CoLockGuard(const CoLockGuard&) = delete;
+    CoLockGuard& operator=(const CoLockGuard&) = delete;
+
+private:
+    Mutex& m_mutex;
+};
+
+/**
+ * @brief RAII 协程锁，支持延迟锁定、try_lock、移动语义
+ * 
+ * 类似 std::unique_lock，提供更灵活的锁管理：
+ * - 延迟锁定（defer_lock）
+ * - 尝试锁定（try_to_lock / try_lock_for）
+ * - 移动语义（可在作用域间转移锁所有权）
+ * - 手动 unlock / lock
+ * 
+ * 析构函数 noexcept — 仅在持有锁时调用 UnLock()。
+ * 
+ * @tparam Mutex 满足 Lockable 概念：Lock() / UnLock() / TryLock() / TryLock(int)
+ */
+template<typename Mutex>
+class CoUniqueLock
+{
+public:
+    CoUniqueLock() noexcept
+        : m_mutex(nullptr)
+        , m_owns(false)
+    {}
+
+    explicit CoUniqueLock(Mutex& m) noexcept(false)
+        : m_mutex(&m)
+        , m_owns(false)
+    {
+        m_mutex->Lock();
+        m_owns = true;
+    }
+
+    CoUniqueLock(Mutex& m, std::defer_lock_t) noexcept
+        : m_mutex(&m)
+        , m_owns(false)
+    {}
+
+    CoUniqueLock(Mutex& m, std::try_to_lock_t) noexcept
+        : m_mutex(&m)
+        , m_owns(false)
+    {
+        m_owns = (m_mutex->TryLock() == 0);
+    }
+
+    CoUniqueLock(Mutex& m, std::adopt_lock_t) noexcept
+        : m_mutex(&m)
+        , m_owns(true)
+    {}
+
+    CoUniqueLock(CoUniqueLock&& other) noexcept
+        : m_mutex(other.m_mutex)
+        , m_owns(other.m_owns)
+    {
+        other.m_mutex = nullptr;
+        other.m_owns = false;
+    }
+
+    CoUniqueLock& operator=(CoUniqueLock&& other) noexcept
+    {
+        if (m_owns) {
+            m_mutex->UnLock();
+        }
+        m_mutex = other.m_mutex;
+        m_owns = other.m_owns;
+        other.m_mutex = nullptr;
+        other.m_owns = false;
+        return *this;
+    }
+
+    ~CoUniqueLock() noexcept
+    {
+        if (m_owns) {
+            m_mutex->UnLock();
+        }
+    }
+
+    CoUniqueLock(const CoUniqueLock&) = delete;
+    CoUniqueLock& operator=(const CoUniqueLock&) = delete;
+
+    void lock() noexcept(false)
+    {
+        AssertWithInfo(m_mutex != nullptr, "CoUniqueLock::lock(): no associated mutex");
+        AssertWithInfo(!m_owns, "CoUniqueLock::lock(): already owns the lock (deadlock would occur)");
+        m_mutex->Lock();
+        m_owns = true;
+    }
+
+    bool try_lock() noexcept
+    {
+        AssertWithInfo(m_mutex != nullptr, "CoUniqueLock::try_lock(): no associated mutex");
+        AssertWithInfo(!m_owns, "CoUniqueLock::try_lock(): already owns the lock");
+        m_owns = (m_mutex->TryLock() == 0);
+        return m_owns;
+    }
+
+    bool try_lock_for(int ms) noexcept
+    {
+        AssertWithInfo(m_mutex != nullptr, "CoUniqueLock::try_lock_for(): no associated mutex");
+        AssertWithInfo(!m_owns, "CoUniqueLock::try_lock_for(): already owns the lock");
+        m_owns = (m_mutex->TryLock(ms) == 0);
+        return m_owns;
+    }
+
+    void unlock() noexcept
+    {
+        AssertWithInfo(m_mutex != nullptr, "CoUniqueLock::unlock(): no associated mutex");
+        AssertWithInfo(m_owns, "CoUniqueLock::unlock(): does not own the lock");
+        m_mutex->UnLock();
+        m_owns = false;
+    }
+
+    bool owns_lock() const noexcept { return m_owns; }
+
+    explicit operator bool() const noexcept { return m_owns; }
+
+    Mutex* mutex() const noexcept { return m_mutex; }
+
+private:
+    Mutex* m_mutex;
+    bool   m_owns;
+};
+
+} // namespace bbt::coroutine::sync

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -46,6 +46,10 @@ add_executable(Test_comutex Test_comutex.cc)
 target_link_libraries(Test_comutex ${MY_LIBS})
 add_test(NAME Test_comutex COMMAND Test_comutex)
 
+add_executable(Test_lockguard Test_lockguard.cc)
+target_link_libraries(Test_lockguard ${MY_LIBS})
+add_test(NAME Test_lockguard COMMAND Test_lockguard)
+
 add_executable(Test_defer Test_defer.cc)
 target_link_libraries(Test_defer ${MY_LIBS})
 add_test(NAME Test_defer COMMAND Test_defer)

--- a/unit_test/Test_lockguard.cc
+++ b/unit_test/Test_lockguard.cc
@@ -1,0 +1,382 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/included/unit_test.hpp>
+
+#include <bbt/core/thread/Lock.hpp>
+#include <bbt/coroutine/coroutine.hpp>
+#include <bbt/coroutine/sync/CoMutex.hpp>
+#include <bbt/coroutine/sync/CoLockGuard.hpp>
+using namespace bbt::coroutine::sync;
+
+BOOST_AUTO_TEST_SUITE(LockGuardTest)
+
+BOOST_AUTO_TEST_CASE(t_scheduler_start)
+{
+    g_scheduler->Start();
+}
+
+// ============ CoLockGuard ============
+
+// 基本 RAII：构造加锁，析构解锁
+BOOST_AUTO_TEST_CASE(t_lockguard_basic)
+{
+    auto mutex = bbtco_make_comutex();
+    int a = 0;
+    const int nco_num = 20;
+    const int nsec = 500;
+    const uint64_t begin = bbt::core::clock::gettime_mono();
+    bbt::core::thread::CountDownLatch l{nco_num};
+
+    for (int i = 0; i < nco_num; ++i) {
+        bbtco [mutex, &a, begin, nsec, &l]()
+        {
+            while ((bbt::core::clock::gettime_mono() - begin) < nsec) {
+                CoLockGuard<CoMutex> guard(*mutex);
+                a++;
+            }
+            l.Down();
+        };
+    }
+
+    l.Wait();
+    BOOST_TEST(a > 0);
+}
+
+// CoLockGuard 释放后其他协程可以获取锁
+BOOST_AUTO_TEST_CASE(t_lockguard_releases_lock)
+{
+    auto mutex = bbtco_make_comutex();
+    int shared = 0;
+    bbt::core::thread::CountDownLatch l{2};
+
+    bbtco [mutex, &shared, &l]()
+    {
+        {
+            CoLockGuard<CoMutex> guard(*mutex);
+            shared = 42;
+        } // guard 析构，释放锁
+        l.Down();
+    };
+
+    bbtco [mutex, &shared, &l]()
+    {
+        CoLockGuard<CoMutex> guard(*mutex);
+        BOOST_TEST(shared == 42);
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// ============ CoUniqueLock ============
+
+// 默认构造：无关联 mutex（不需要协程上下文）
+BOOST_AUTO_TEST_CASE(t_unique_default_ctor)
+{
+    CoUniqueLock<CoMutex> lock;
+    BOOST_TEST(!lock.owns_lock());
+    BOOST_TEST(!lock.owns_lock());
+    BOOST_TEST(lock.mutex() == nullptr);
+}
+
+// 正常锁定（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_lock_basic)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex);
+        BOOST_TEST(lock.owns_lock());
+        BOOST_TEST(lock.owns_lock());
+        BOOST_TEST(lock.mutex() == mutex.get());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// defer_lock + 手动 lock/unlock（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_defer_lock)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        BOOST_TEST(!lock.owns_lock());
+
+        lock.lock();
+        BOOST_TEST(lock.owns_lock());
+
+        lock.unlock();
+        BOOST_TEST(!lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// try_to_lock（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_try_to_lock)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex, std::try_to_lock);
+        // 初始状态锁是空闲的，应该成功
+        BOOST_TEST(lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// try_lock_for 超时
+BOOST_AUTO_TEST_CASE(t_unique_try_lock_for_timeout)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{2};
+
+    // 协程 A：持有锁一段时间
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex);
+        BOOST_TEST(lock.owns_lock());
+        bbtco_sleep(200); // 持有 200ms
+        l.Down();
+    };
+
+    // 协程 B：尝试在 50ms 内获取锁（应该超时）
+    bbtco [mutex, &l]()
+    {
+        // 等一会儿确保 A 先获得锁
+        bbtco_sleep(10);
+        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        bool got = lock.try_lock_for(50);
+        BOOST_TEST(!got);
+        BOOST_TEST(!lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// try_lock_for 成功
+BOOST_AUTO_TEST_CASE(t_unique_try_lock_for_success)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        bool got = lock.try_lock_for(500);
+        BOOST_TEST(got);
+        BOOST_TEST(lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// adopt_lock（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_adopt_lock)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        mutex->Lock();
+        {
+            CoUniqueLock<CoMutex> lock(*mutex, std::adopt_lock);
+            BOOST_TEST(lock.owns_lock());
+        } // 析构时 UnLock
+        // 验证锁已释放：可以再次获取
+        CoUniqueLock<CoMutex> lock2(*mutex);
+        BOOST_TEST(lock2.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 移动构造（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_move_ctor)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock1(*mutex);
+        BOOST_TEST(lock1.owns_lock());
+
+        CoUniqueLock<CoMutex> lock2(std::move(lock1));
+        BOOST_TEST(!lock1.owns_lock());
+        BOOST_TEST(lock1.mutex() == nullptr);
+        BOOST_TEST(lock2.owns_lock());
+        BOOST_TEST(lock2.mutex() == mutex.get());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 移动赋值（在协程内）
+BOOST_AUTO_TEST_CASE(t_unique_move_assign)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock1(*mutex);
+        CoUniqueLock<CoMutex> lock2;
+
+        lock2 = std::move(lock1);
+        BOOST_TEST(!lock1.owns_lock());
+        BOOST_TEST(lock2.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 移动赋值时，目标对象如果持有锁，先释放
+BOOST_AUTO_TEST_CASE(t_unique_move_assign_release)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{1};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock1(*mutex);
+        BOOST_TEST(lock1.owns_lock());
+
+        CoUniqueLock<CoMutex> lock2;
+        lock1.unlock(); // 先释放
+        lock2 = std::move(lock1);
+        BOOST_TEST(!lock1.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 析构释放锁：scope exit 自动 unlock
+BOOST_AUTO_TEST_CASE(t_unique_destructor_unlocks)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{2};
+
+    bbtco [mutex, &l]()
+    {
+        {
+            CoUniqueLock<CoMutex> lock(*mutex);
+            BOOST_TEST(lock.owns_lock());
+        } // 析构释放锁
+        l.Down();
+    };
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex);
+        BOOST_TEST(lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 异常安全：异常抛出时析构自动释放锁
+BOOST_AUTO_TEST_CASE(t_unique_exception_safety)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{2};
+
+    bbtco [mutex, &l]()
+    {
+        try {
+            CoUniqueLock<CoMutex> lock(*mutex);
+            throw std::runtime_error("test exception");
+        } catch (...) {
+            // lock 析构已释放锁
+        }
+        l.Down();
+    };
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex);
+        BOOST_TEST(lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// 移动后释放：移动到的对象析构时正确释放锁
+BOOST_AUTO_TEST_CASE(t_unique_move_then_release)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{2};
+
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> inner;
+        {
+            CoUniqueLock<CoMutex> outer(*mutex);
+            inner = std::move(outer);
+        } // outer 析构（已不持有锁，安全）
+        BOOST_TEST(inner.owns_lock());
+        l.Down();
+    }; // inner 析构释放锁
+
+    // 验证锁已释放：另一个协程可以获取
+    bbtco [mutex, &l]()
+    {
+        CoUniqueLock<CoMutex> lock(*mutex);
+        BOOST_TEST(lock.owns_lock());
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+// CoLockGuard 异常安全
+BOOST_AUTO_TEST_CASE(t_lockguard_exception_safety)
+{
+    auto mutex = bbtco_make_comutex();
+    bbt::core::thread::CountDownLatch l{2};
+
+    bbtco [mutex, &l]()
+    {
+        try {
+            CoLockGuard<CoMutex> guard(*mutex);
+            throw std::runtime_error("test");
+        } catch (...) {}
+        l.Down();
+    };
+
+    bbtco [mutex, &l]()
+    {
+        CoLockGuard<CoMutex> guard(*mutex);
+        BOOST_TEST(true);
+        l.Down();
+    };
+
+    l.Wait();
+}
+
+BOOST_AUTO_TEST_CASE(t_scheduler_end)
+{
+    g_scheduler->Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 概述

实现两种协程锁 RAII 包装，解决 #185：
- **CoLockGuard<Mutex>**: 简单 scope guard，构造 Lock，析构 UnLock(nothrow)
- **CoUniqueLock<Mutex>**: 灵活锁，支持 defer_lock/try_to_lock/adopt_lock/try_lock_for(ms)/移动语义/手动 lock-unlock

## 特性

- ✅ 析构函数 `noexcept` — 异常路径下也能正确释放锁
- ✅ 移动语义 — CoUniqueLock 可在作用域间转移所有权
- ✅ 死锁检测 — 由底层 `CoMutex::Lock()` 内部 assert 实现
- ✅ 模板化设计 — 可复用于其他满足 Lockable 概念的类型

## 测试覆盖 (18/18 pass)

| 类别 | 测试 |
|------|------|
| CoLockGuard | 基本 RAII、锁释放验证、异常安全 |
| CoUniqueLock | 默认构造、正常锁定、defer_lock、try_to_lock |
| | try_lock_for 超时、try_lock_for 成功、adopt_lock |
| | 移动构造、移动赋值、移动前释放 |
| | 析构自动 unlock、异常安全、移动后释放 |

Closes #185