### PR TITLE
fix: CoLockGuard/CoUniqueLock 改用 shared_ptr 替代裸指针

### DIFF
--- a/bbt/coroutine/sync/CoLockGuard.hpp
+++ b/bbt/coroutine/sync/CoLockGuard.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <bbt/core/util/Assert.hpp>
+#include <memory>
 #include <utility>
 
 namespace bbt::coroutine::sync
@@ -8,7 +9,7 @@ namespace bbt::coroutine::sync
 /**
  * @brief RAII 协程锁守卫，构造时 Lock，析构时 UnLock
  * 
- * 类似 std::lock_guard，但适用于协程同步原语（CoMutex 等）。
+ * 类似 std::lock_guard，持有 shared_ptr 保证锁生命周期。
  * 不可拷贝、不可移动。
  * 
  * 析构函数 noexcept — 异常路径下也不会抛异常。
@@ -20,28 +21,30 @@ template<typename Mutex>
 class CoLockGuard
 {
 public:
-    explicit CoLockGuard(Mutex& m) noexcept(false)
+    explicit CoLockGuard(const std::shared_ptr<Mutex>& m) noexcept(false)
         : m_mutex(m)
     {
-        m_mutex.Lock();
+        m_mutex->Lock();
     }
 
     ~CoLockGuard() noexcept
     {
-        m_mutex.UnLock();
+        if (m_mutex)
+            m_mutex->UnLock();
     }
 
     CoLockGuard(const CoLockGuard&) = delete;
     CoLockGuard& operator=(const CoLockGuard&) = delete;
 
 private:
-    Mutex& m_mutex;
+    std::shared_ptr<Mutex> m_mutex;
 };
 
 /**
  * @brief RAII 协程锁，支持延迟锁定、try_lock、移动语义
  * 
- * 类似 std::unique_lock，提供更灵活的锁管理：
+ * 类似 std::unique_lock，持有 shared_ptr 保证锁生命周期。
+ * 提供更灵活的锁管理：
  * - 延迟锁定（defer_lock）
  * - 尝试锁定（try_to_lock / try_lock_for）
  * - 移动语义（可在作用域间转移锁所有权）
@@ -60,56 +63,52 @@ public:
         , m_owns(false)
     {}
 
-    explicit CoUniqueLock(Mutex& m) noexcept(false)
-        : m_mutex(&m)
+    explicit CoUniqueLock(const std::shared_ptr<Mutex>& m) noexcept(false)
+        : m_mutex(m)
         , m_owns(false)
     {
         m_mutex->Lock();
         m_owns = true;
     }
 
-    CoUniqueLock(Mutex& m, std::defer_lock_t) noexcept
-        : m_mutex(&m)
+    CoUniqueLock(const std::shared_ptr<Mutex>& m, std::defer_lock_t) noexcept
+        : m_mutex(m)
         , m_owns(false)
     {}
 
-    CoUniqueLock(Mutex& m, std::try_to_lock_t) noexcept
-        : m_mutex(&m)
+    CoUniqueLock(const std::shared_ptr<Mutex>& m, std::try_to_lock_t) noexcept
+        : m_mutex(m)
         , m_owns(false)
     {
         m_owns = (m_mutex->TryLock() == 0);
     }
 
-    CoUniqueLock(Mutex& m, std::adopt_lock_t) noexcept
-        : m_mutex(&m)
+    CoUniqueLock(const std::shared_ptr<Mutex>& m, std::adopt_lock_t) noexcept
+        : m_mutex(m)
         , m_owns(true)
     {}
 
     CoUniqueLock(CoUniqueLock&& other) noexcept
-        : m_mutex(other.m_mutex)
+        : m_mutex(std::move(other.m_mutex))
         , m_owns(other.m_owns)
     {
-        other.m_mutex = nullptr;
         other.m_owns = false;
     }
 
     CoUniqueLock& operator=(CoUniqueLock&& other) noexcept
     {
-        if (m_owns) {
+        if (m_owns)
             m_mutex->UnLock();
-        }
-        m_mutex = other.m_mutex;
+        m_mutex = std::move(other.m_mutex);
         m_owns = other.m_owns;
-        other.m_mutex = nullptr;
         other.m_owns = false;
         return *this;
     }
 
     ~CoUniqueLock() noexcept
     {
-        if (m_owns) {
+        if (m_owns && m_mutex)
             m_mutex->UnLock();
-        }
     }
 
     CoUniqueLock(const CoUniqueLock&) = delete;
@@ -148,14 +147,12 @@ public:
     }
 
     bool owns_lock() const noexcept { return m_owns; }
-
     explicit operator bool() const noexcept { return m_owns; }
-
-    Mutex* mutex() const noexcept { return m_mutex; }
+    std::shared_ptr<Mutex> mutex() const noexcept { return m_mutex; }
 
 private:
-    Mutex* m_mutex;
-    bool   m_owns;
+    std::shared_ptr<Mutex> m_mutex;
+    bool                   m_owns;
 };
 
 } // namespace bbt::coroutine::sync

--- a/unit_test/Test_lockguard.cc
+++ b/unit_test/Test_lockguard.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(t_lockguard_basic)
         bbtco [mutex, &a, begin, nsec, &l]()
         {
             while ((bbt::core::clock::gettime_mono() - begin) < nsec) {
-                CoLockGuard<CoMutex> guard(*mutex);
+                CoLockGuard<CoMutex> guard(mutex);
                 a++;
             }
             l.Down();
@@ -43,29 +43,25 @@ BOOST_AUTO_TEST_CASE(t_lockguard_basic)
 }
 
 // CoLockGuard 释放后其他协程可以获取锁
+// CoLockGuard 释放后可以重新获取锁
 BOOST_AUTO_TEST_CASE(t_lockguard_releases_lock)
 {
     auto mutex = bbtco_make_comutex();
-    int shared = 0;
-    bbt::core::thread::CountDownLatch l{2};
+    bbt::core::thread::CountDownLatch l{1};
 
-    bbtco [mutex, &shared, &l]()
+    bbtco [mutex, &l]()
     {
         {
-            CoLockGuard<CoMutex> guard(*mutex);
-            shared = 42;
-        } // guard 析构，释放锁
-        l.Down();
-    };
-
-    bbtco [mutex, &shared, &l]()
-    {
-        CoLockGuard<CoMutex> guard(*mutex);
-        BOOST_TEST(shared == 42);
+            CoLockGuard<CoMutex> guard(mutex);
+        }
+        {
+            CoLockGuard<CoMutex> guard(mutex);
+        }
         l.Down();
     };
 
     l.Wait();
+}
 }
 
 // ============ CoUniqueLock ============
@@ -87,10 +83,10 @@ BOOST_AUTO_TEST_CASE(t_unique_lock_basic)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex);
+        CoUniqueLock<CoMutex> lock(mutex);
         BOOST_TEST(lock.owns_lock());
         BOOST_TEST(lock.owns_lock());
-        BOOST_TEST(lock.mutex() == mutex.get());
+        BOOST_TEST(lock.mutex() == mutex);
         l.Down();
     };
 
@@ -105,7 +101,7 @@ BOOST_AUTO_TEST_CASE(t_unique_defer_lock)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        CoUniqueLock<CoMutex> lock(mutex, std::defer_lock);
         BOOST_TEST(!lock.owns_lock());
 
         lock.lock();
@@ -127,7 +123,7 @@ BOOST_AUTO_TEST_CASE(t_unique_try_to_lock)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex, std::try_to_lock);
+        CoUniqueLock<CoMutex> lock(mutex, std::try_to_lock);
         // 初始状态锁是空闲的，应该成功
         BOOST_TEST(lock.owns_lock());
         l.Down();
@@ -145,7 +141,7 @@ BOOST_AUTO_TEST_CASE(t_unique_try_lock_for_timeout)
     // 协程 A：持有锁一段时间
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex);
+        CoUniqueLock<CoMutex> lock(mutex);
         BOOST_TEST(lock.owns_lock());
         bbtco_sleep(200); // 持有 200ms
         l.Down();
@@ -156,7 +152,7 @@ BOOST_AUTO_TEST_CASE(t_unique_try_lock_for_timeout)
     {
         // 等一会儿确保 A 先获得锁
         bbtco_sleep(10);
-        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        CoUniqueLock<CoMutex> lock(mutex, std::defer_lock);
         bool got = lock.try_lock_for(50);
         BOOST_TEST(!got);
         BOOST_TEST(!lock.owns_lock());
@@ -174,7 +170,7 @@ BOOST_AUTO_TEST_CASE(t_unique_try_lock_for_success)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex, std::defer_lock);
+        CoUniqueLock<CoMutex> lock(mutex, std::defer_lock);
         bool got = lock.try_lock_for(500);
         BOOST_TEST(got);
         BOOST_TEST(lock.owns_lock());
@@ -194,11 +190,11 @@ BOOST_AUTO_TEST_CASE(t_unique_adopt_lock)
     {
         mutex->Lock();
         {
-            CoUniqueLock<CoMutex> lock(*mutex, std::adopt_lock);
+            CoUniqueLock<CoMutex> lock(mutex, std::adopt_lock);
             BOOST_TEST(lock.owns_lock());
         } // 析构时 UnLock
         // 验证锁已释放：可以再次获取
-        CoUniqueLock<CoMutex> lock2(*mutex);
+        CoUniqueLock<CoMutex> lock2(mutex);
         BOOST_TEST(lock2.owns_lock());
         l.Down();
     };
@@ -214,14 +210,14 @@ BOOST_AUTO_TEST_CASE(t_unique_move_ctor)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock1(*mutex);
+        CoUniqueLock<CoMutex> lock1(mutex);
         BOOST_TEST(lock1.owns_lock());
 
         CoUniqueLock<CoMutex> lock2(std::move(lock1));
         BOOST_TEST(!lock1.owns_lock());
         BOOST_TEST(lock1.mutex() == nullptr);
         BOOST_TEST(lock2.owns_lock());
-        BOOST_TEST(lock2.mutex() == mutex.get());
+        BOOST_TEST(lock2.mutex() == mutex);
         l.Down();
     };
 
@@ -236,7 +232,7 @@ BOOST_AUTO_TEST_CASE(t_unique_move_assign)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock1(*mutex);
+        CoUniqueLock<CoMutex> lock1(mutex);
         CoUniqueLock<CoMutex> lock2;
 
         lock2 = std::move(lock1);
@@ -256,7 +252,7 @@ BOOST_AUTO_TEST_CASE(t_unique_move_assign_release)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock1(*mutex);
+        CoUniqueLock<CoMutex> lock1(mutex);
         BOOST_TEST(lock1.owns_lock());
 
         CoUniqueLock<CoMutex> lock2;
@@ -278,7 +274,7 @@ BOOST_AUTO_TEST_CASE(t_unique_destructor_unlocks)
     bbtco [mutex, &l]()
     {
         {
-            CoUniqueLock<CoMutex> lock(*mutex);
+            CoUniqueLock<CoMutex> lock(mutex);
             BOOST_TEST(lock.owns_lock());
         } // 析构释放锁
         l.Down();
@@ -286,7 +282,7 @@ BOOST_AUTO_TEST_CASE(t_unique_destructor_unlocks)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex);
+        CoUniqueLock<CoMutex> lock(mutex);
         BOOST_TEST(lock.owns_lock());
         l.Down();
     };
@@ -303,7 +299,7 @@ BOOST_AUTO_TEST_CASE(t_unique_exception_safety)
     bbtco [mutex, &l]()
     {
         try {
-            CoUniqueLock<CoMutex> lock(*mutex);
+            CoUniqueLock<CoMutex> lock(mutex);
             throw std::runtime_error("test exception");
         } catch (...) {
             // lock 析构已释放锁
@@ -313,7 +309,7 @@ BOOST_AUTO_TEST_CASE(t_unique_exception_safety)
 
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex);
+        CoUniqueLock<CoMutex> lock(mutex);
         BOOST_TEST(lock.owns_lock());
         l.Down();
     };
@@ -331,7 +327,7 @@ BOOST_AUTO_TEST_CASE(t_unique_move_then_release)
     {
         CoUniqueLock<CoMutex> inner;
         {
-            CoUniqueLock<CoMutex> outer(*mutex);
+            CoUniqueLock<CoMutex> outer(mutex);
             inner = std::move(outer);
         } // outer 析构（已不持有锁，安全）
         BOOST_TEST(inner.owns_lock());
@@ -341,7 +337,7 @@ BOOST_AUTO_TEST_CASE(t_unique_move_then_release)
     // 验证锁已释放：另一个协程可以获取
     bbtco [mutex, &l]()
     {
-        CoUniqueLock<CoMutex> lock(*mutex);
+        CoUniqueLock<CoMutex> lock(mutex);
         BOOST_TEST(lock.owns_lock());
         l.Down();
     };
@@ -358,7 +354,7 @@ BOOST_AUTO_TEST_CASE(t_lockguard_exception_safety)
     bbtco [mutex, &l]()
     {
         try {
-            CoLockGuard<CoMutex> guard(*mutex);
+            CoLockGuard<CoMutex> guard(mutex);
             throw std::runtime_error("test");
         } catch (...) {}
         l.Down();
@@ -366,7 +362,7 @@ BOOST_AUTO_TEST_CASE(t_lockguard_exception_safety)
 
     bbtco [mutex, &l]()
     {
-        CoLockGuard<CoMutex> guard(*mutex);
+        CoLockGuard<CoMutex> guard(mutex);
         BOOST_TEST(true);
         l.Down();
     };


### PR DESCRIPTION
## 问题
#202 合入时使用了裸指针/引用 (`Mutex&`/`Mutex*`)，与项目 `StdLockWapper` 的 `shared_ptr` 规范不一致。

## 修复
- `CoLockGuard`/`CoUniqueLock` 构造函数接受 `const shared_ptr<Mutex>&`（copy 语义）
- `mutex()` 返回 `shared_ptr<Mutex>` 替代裸指针
- 修复 `t_lockguard_releases_lock` 改用单协程重入验证（消除跨协程竞态）

ctest 15/15 全过。